### PR TITLE
fix: add missing HOMEBREW_TAP_GITHUB_TOKEN to goreleaser and workflow…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Build MCPB bundles
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -144,6 +144,7 @@ brews:
     repository:
       owner: txn2
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
     homepage: https://github.com/txn2/mcp-trino
     description: MCP server for Trino data warehouses


### PR DESCRIPTION
fix: add missing HOMEBREW_TAP_GITHUB_TOKEN to goreleaser and workflow config