### PR TITLE
Add Release Notes for v0.2.0 and v0.2.1

### DIFF
--- a/docs/changelog/RELEASE_v0.2.0.md
+++ b/docs/changelog/RELEASE_v0.2.0.md
@@ -1,0 +1,98 @@
+# v0.2.0 - Semantic Layer
+
+A backward-compatible release introducing a **Semantic Layer** that enriches AI assistant understanding with organizational context beyond basic table structures.
+
+## Features
+
+### Semantic Layer Capabilities
+Adds eight metadata categories to enrich table and column descriptions:
+- **Business descriptions** - Human-readable context for data assets
+- **Ownership details** - Data owners and stewards
+- **Tags** - Classification and categorization labels
+- **Glossary terms** - Business terminology associations
+- **Data quality scores** - Quality indicators and metrics
+- **Sensitivity markers** - PII and data classification
+- **Deprecation alerts** - Lifecycle status warnings
+- **Lineage information** - Data flow and dependencies
+
+### Provider Options
+Three metadata sources are supported:
+- **DataHub** - Enterprise metadata catalogs via GraphQL API
+- **Static** - YAML/JSON files with hot-reload capability
+- **Custom** - Implement the `semantic.Provider` interface for custom sources
+
+### Performance Characteristics
+- **Zero Overhead** - No performance impact when semantic layer is unconfigured
+- **Built-in Caching** - Reduces latency with configurable TTL and entry limits
+- **Provider Chaining** - Combine multiple providers with fallback logic
+- **ProviderFunc** - Simple inline providers for lightweight customization
+
+## Configuration
+
+### Environment Variables
+
+**DataHub Provider:**
+```bash
+export DATAHUB_ENDPOINT=https://datahub.example.com
+export DATAHUB_TOKEN=your_token
+```
+
+**Static Provider:**
+```bash
+export SEMANTIC_STATIC_FILE=/path/to/metadata.yaml
+```
+
+### Programmatic Configuration
+```go
+toolkit := tools.NewToolkit(trinoClient, tools.DefaultConfig(),
+    tools.WithSemanticProvider(provider),
+    tools.WithSemanticCache(5*time.Minute, 1000),
+)
+```
+
+## Installation
+
+### Homebrew (macOS)
+```bash
+brew upgrade txn2/tap/mcp-trino
+```
+
+### Claude Desktop
+Download the `.mcpb` bundle for your platform from the [releases page](https://github.com/txn2/mcp-trino/releases/tag/v0.2.0):
+- macOS Apple Silicon: `mcp-trino_0.2.0_darwin_arm64.mcpb`
+- macOS Intel: `mcp-trino_0.2.0_darwin_amd64.mcpb`
+- Windows: `mcp-trino_0.2.0_windows_amd64.mcpb`
+
+### Claude Code CLI
+```bash
+claude mcp add trino \
+  -e TRINO_HOST=trino.example.com \
+  -e TRINO_USER=your_user \
+  -e TRINO_PASSWORD=your_password \
+  -- mcp-trino
+```
+
+### Docker
+```bash
+docker pull ghcr.io/txn2/mcp-trino:v0.2.0
+```
+
+### Go Install
+```bash
+go install github.com/txn2/mcp-trino/cmd/mcp-trino@v0.2.0
+```
+
+## Additional Changes
+
+- Removed pre-built documentation directories from repository
+- Expanded README documentation
+- Added Docker Compose testing infrastructure (e2e)
+- Added extensibility guides for library users
+
+## Verification
+
+All artifacts are signed with Cosign (keyless). Verify with:
+```bash
+cosign verify-blob --bundle mcp-trino_0.2.0_linux_amd64.tar.gz.sigstore.json \
+  mcp-trino_0.2.0_linux_amd64.tar.gz
+```

--- a/docs/changelog/RELEASE_v0.2.1.md
+++ b/docs/changelog/RELEASE_v0.2.1.md
@@ -1,0 +1,66 @@
+# v0.2.1 - SQL Identifier Quoting Fix
+
+A patch release that fixes SQL identifier quoting to properly handle special characters and prevent potential injection.
+
+## Bug Fixes
+
+### SQL Identifier Quoting (#17)
+- **Fixed**: SQL identifiers (catalog, schema, table names) are now properly quoted using double quotes per SQL standard
+- **Security**: Prevents potential issues when identifiers contain special characters
+- **Compatibility**: Handles reserved keywords, spaces, and special characters in identifier names
+
+#### Affected Operations
+- `SHOW SCHEMAS FROM <catalog>`
+- `SHOW TABLES FROM <catalog>.<schema>`
+- `DESCRIBE <catalog>.<schema>.<table>`
+- `SELECT * FROM <catalog>.<schema>.<table>` (sample data queries)
+
+#### Technical Details
+Added `QuoteIdentifier()` function in `pkg/client/client.go` that:
+- Wraps identifiers in double quotes
+- Escapes internal double quotes by doubling them (SQL standard)
+- Applied to all dynamic SQL identifier interpolation
+
+## Installation
+
+### Homebrew (macOS)
+```bash
+brew upgrade txn2/tap/mcp-trino
+```
+
+### Claude Desktop
+Download the `.mcpb` bundle for your platform from the [releases page](https://github.com/txn2/mcp-trino/releases/tag/v0.2.1):
+- macOS Apple Silicon: `mcp-trino_0.2.1_darwin_arm64.mcpb`
+- macOS Intel: `mcp-trino_0.2.1_darwin_amd64.mcpb`
+- Windows: `mcp-trino_0.2.1_windows_amd64.mcpb`
+
+### Claude Code CLI
+```bash
+claude mcp add trino \
+  -e TRINO_HOST=trino.example.com \
+  -e TRINO_USER=your_user \
+  -e TRINO_PASSWORD=your_password \
+  -- mcp-trino
+```
+
+### Docker
+```bash
+docker pull ghcr.io/txn2/mcp-trino:v0.2.1
+```
+
+### Go Install
+```bash
+go install github.com/txn2/mcp-trino/cmd/mcp-trino@v0.2.1
+```
+
+## Verification
+
+All artifacts are signed with Cosign (keyless). Verify with:
+```bash
+cosign verify-blob --bundle mcp-trino_0.2.1_linux_amd64.tar.gz.sigstore.json \
+  mcp-trino_0.2.1_linux_amd64.tar.gz
+```
+
+## Upgrade Notes
+
+This is a recommended upgrade for all users. No configuration changes required.


### PR DESCRIPTION
## Summary

Added missing changelog documentation for the v0.2.0 Semantic Layer release and the v0.2.1 SQL identifier quoting fix.

## Problem

The `docs/changelog/` directory only contained `RELEASE_v0.1.1.md`. Release notes for v0.2.0 and v0.2.1 were missing from the repository, though v0.2.0 notes existed on GitHub releases.

## Solution

Created two new release notes files following the established pattern:

| File | Description |
|------|-------------|
| `docs/changelog/RELEASE_v0.2.0.md` | Semantic Layer release documentation |
| `docs/changelog/RELEASE_v0.2.1.md` | SQL Identifier Quoting Fix documentation |

## Changes

### `docs/changelog/RELEASE_v0.2.0.md`
Documents the Semantic Layer release including:
- Eight metadata categories (descriptions, ownership, tags, glossary, quality, sensitivity, deprecation, lineage)
- Three provider options (DataHub, Static, Custom)
- Performance features (zero overhead, caching, provider chaining)
- Environment variable and programmatic configuration examples
- Installation instructions for all platforms

### `docs/changelog/RELEASE_v0.2.1.md`
Documents the patch release including:
- SQL identifier quoting bug fix (#17)
- Affected operations list
- Technical details of `QuoteIdentifier()` function
- Installation and verification instructions

## References

- GitHub Release v0.2.0: https://github.com/txn2/mcp-trino/releases/tag/v0.2.0
- PR #14: Semantic Provider Implementation
- PR #15: Docs/Semantic Layer
- PR #17: Fix SQL Identifier Quoting Bug
