### PR TITLE
feat: add ProgressNotifier interface for granular query progress

### DIFF
--- a/pkg/tools/progress.go
+++ b/pkg/tools/progress.go
@@ -1,0 +1,28 @@
+package tools
+
+import "context"
+
+// ProgressNotifier sends progress notifications during tool execution.
+// The platform injects an implementation via ToolMiddleware that bridges
+// to the MCP ServerSession.
+type ProgressNotifier interface {
+	// Notify sends a progress update.
+	// progress is the current step, total is the total number of steps.
+	// message describes the current operation.
+	Notify(ctx context.Context, progress, total float64, message string) error
+}
+
+// progressNotifierKey is the context key for ProgressNotifier.
+type progressNotifierKey struct{}
+
+// WithProgressNotifier returns a new context with the given ProgressNotifier.
+func WithProgressNotifier(ctx context.Context, n ProgressNotifier) context.Context {
+	return context.WithValue(ctx, progressNotifierKey{}, n)
+}
+
+// GetProgressNotifier retrieves the ProgressNotifier from the context.
+// Returns nil if no notifier is set.
+func GetProgressNotifier(ctx context.Context) ProgressNotifier {
+	n, _ := ctx.Value(progressNotifierKey{}).(ProgressNotifier) //nolint:errcheck // type assertion ok is unused by design
+	return n
+}

--- a/pkg/tools/progress_test.go
+++ b/pkg/tools/progress_test.go
@@ -1,0 +1,77 @@
+package tools
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+// testNotifier records calls for testing.
+type testNotifier struct {
+	calls atomic.Int32
+}
+
+func (n *testNotifier) Notify(_ context.Context, _, _ float64, _ string) error {
+	n.calls.Add(1)
+	return nil
+}
+
+func TestWithProgressNotifier_RoundTrip(t *testing.T) {
+	notifier := &testNotifier{}
+	ctx := WithProgressNotifier(context.Background(), notifier)
+
+	got := GetProgressNotifier(ctx)
+	if got == nil {
+		t.Fatal("expected notifier, got nil")
+	}
+
+	if err := got.Notify(ctx, 1, 3, "test"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if notifier.calls.Load() != 1 {
+		t.Fatalf("expected 1 call, got %d", notifier.calls.Load())
+	}
+}
+
+func TestGetProgressNotifier_NilContext(t *testing.T) {
+	// No notifier in context should return nil.
+	got := GetProgressNotifier(context.Background())
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestNotifyProgress_NilNotifier(_ *testing.T) {
+	// Should not panic with nil notifier.
+	notifyProgress(context.Background(), nil, 0, 3, "test")
+}
+
+func TestNotifyProgress_WithNotifier(t *testing.T) {
+	n := &testNotifier{}
+	notifyProgress(context.Background(), n, 1, 3, "step 1")
+	if n.calls.Load() != 1 {
+		t.Fatalf("expected 1 call, got %d", n.calls.Load())
+	}
+}
+
+func TestWithProgressNotifier_Overwrite(t *testing.T) {
+	n1 := &testNotifier{}
+	n2 := &testNotifier{}
+
+	ctx := WithProgressNotifier(context.Background(), n1)
+	ctx = WithProgressNotifier(ctx, n2)
+
+	got := GetProgressNotifier(ctx)
+	if got == nil {
+		t.Fatal("expected notifier, got nil")
+	}
+
+	// Should be n2, not n1.
+	_ = got.Notify(ctx, 1, 1, "check") //nolint:errcheck // test
+	if n1.calls.Load() != 0 {
+		t.Fatal("first notifier should not have been called")
+	}
+	if n2.calls.Load() != 1 {
+		t.Fatal("second notifier should have been called")
+	}
+}


### PR DESCRIPTION
## Summary

- Add a `ProgressNotifier` interface that allows platform middleware to inject progress callbacks into query execution
- Integrate three granular notification points in `handleQuery()`: before query, after query returns (with row count), and after formatting
- Pass notifier via `context.Context` using `WithProgressNotifier`/`GetProgressNotifier` helpers — zero overhead when no notifier is injected

## Motivation

MCP clients that send `_meta.progressToken` with tool calls expect granular progress updates during long-running operations. Trino queries can take seconds to minutes, and without progress feedback, clients have no visibility into execution state.

This PR adds the **toolkit-side** of the progress notification pipeline. The platform (mcp-data-platform) provides the MCP protocol adapter that bridges `ProgressNotifier` to `ServerSession.NotifyProgress()` via a `ToolMiddleware` injector.

## Design

```
MCP Client sends tools/call with _meta.progressToken
  → Platform MCPToolCallMiddleware stores session + token in ctx
    → ProgressInjector.Before() creates MCPProgressNotifier from ctx
      → handleQuery() calls GetProgressNotifier(ctx)
        → Notify(0/3, "Executing query...")
        → trinoClient.Query(ctx, sql)     ← blocking
        → Notify(1/3, "Query returned N rows, formatting...")
        → format output
        → Notify(2/3, "Query complete")
```

### Key decisions

- **Interface in toolkit, adapter in platform**: The `ProgressNotifier` interface lives here (no MCP SDK dependency needed). The platform creates the concrete adapter that wraps `*mcp.ServerSession`.
- **Context-based injection**: Follows the same pattern as `ToolMiddleware` — the notifier is injected via `context.WithValue` in a `Before()` hook, retrieved in the handler.
- **Best-effort**: All `Notify()` errors are silently ignored. Progress is informational; a notification failure must never break query execution.
- **Nil-safe**: `notifyProgress()` is a nil-guarded helper — when no notifier is in context (the default), calls are free.

## Changes

| File | Description |
|---|---|
| `pkg/tools/progress.go` | `ProgressNotifier` interface, `WithProgressNotifier()`, `GetProgressNotifier()` |
| `pkg/tools/progress_test.go` | Round-trip, nil context, overwrite, nil notifier, notifier invocation tests |
| `pkg/tools/query.go` | `notifyProgress()` helper + 3 notification points in `handleQuery()` |

## Test plan

- [x] `WithProgressNotifier`/`GetProgressNotifier` round-trip
- [x] `GetProgressNotifier` returns nil on empty context
- [x] `notifyProgress` with nil notifier does not panic
- [x] `notifyProgress` with real notifier invokes `Notify()`
- [x] Overwriting notifier in context uses latest
- [x] `make verify` passes (lint, tests, race, coverage)