### PR TITLE
fix: create release as draft to allow MCPB bundle uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,12 @@ jobs:
           # Publish the server to the MCP registry
           mcp-publisher publish
 
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "$GITHUB_REF_NAME" --draft=false
+
   # NOTE: SLSA provenance job removed due to false positive "private repository" detection
   # See: https://github.com/slsa-framework/slsa-github-generator/issues
   # The workflow incorrectly detects public repos as private and halts.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -170,6 +170,7 @@ release:
     name: mcp-trino
   name_template: "{{.ProjectName}}-v{{.Version}}"
   prerelease: auto
+  draft: true
   mode: append
   footer: |
     ## Installation


### PR DESCRIPTION
## Summary
- GoReleaser now creates the GitHub release as a **draft** (`draft: true` in `.goreleaser.yml`)
- After all MCPB bundles are built, signed, uploaded, and the MCP Registry is published, the release is published via `gh release edit --draft=false`
- Fixes `HTTP 422: Cannot upload assets to an immutable release` error from v0.6.0 release ([run #22055089370](https://github.com/txn2/mcp-trino/actions/runs/22055089370))

## Test plan
- [ ] Tag v0.6.1 after merge and verify the release workflow completes successfully
- [ ] Verify MCPB bundles appear in the published release
- [ ] Verify Homebrew formula is updated