### PR TITLE
feat: add default icons for all tools

### DIFF
--- a/icons/trino.svg
+++ b/icons/trino.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#DD00A1"/>
+  <path d="M20 16h8l16 16-16 16h-8l16-16L20 16z" fill="white"/>
+</svg>

--- a/pkg/tools/connections.go
+++ b/pkg/tools/connections.go
@@ -43,6 +43,7 @@ func (t *Toolkit) registerListConnectionsTool(server *mcp.Server, cfg *toolConfi
 		Name:        string(ToolListConnections),
 		Description: t.getDescription(ToolListConnections, cfg),
 		Annotations: t.getAnnotations(ToolListConnections, cfg),
+		Icons:       t.getIcons(ToolListConnections, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListConnectionsInput) (*mcp.CallToolResult, *ListConnectionsOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*ListConnectionsOutput); ok {

--- a/pkg/tools/explain.go
+++ b/pkg/tools/explain.go
@@ -43,6 +43,7 @@ func (t *Toolkit) registerExplainTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolExplain),
 		Description: t.getDescription(ToolExplain, cfg),
 		Annotations: t.getAnnotations(ToolExplain, cfg),
+		Icons:       t.getIcons(ToolExplain, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ExplainInput) (*mcp.CallToolResult, *ExplainOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*ExplainOutput); ok {

--- a/pkg/tools/icons.go
+++ b/pkg/tools/icons.go
@@ -1,0 +1,35 @@
+package tools
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+// defaultIcons holds the default icon for all Trino tools.
+// Uses a GitHub-hosted SVG from the mcp-trino repository.
+var defaultIcons = []mcp.Icon{{
+	Source:   "https://raw.githubusercontent.com/txn2/mcp-trino/main/icons/trino.svg",
+	MIMEType: "image/svg+xml",
+}}
+
+// DefaultIcons returns the default icons for a tool.
+// Returns the toolkit-wide defaults for all tools.
+func DefaultIcons() []mcp.Icon {
+	return defaultIcons
+}
+
+// getIcons resolves the icons for a tool using the priority chain:
+// 1. Per-registration override (cfg.icons) — highest priority
+// 2. Toolkit-level override (t.icons) — medium priority
+// 3. Default icons — lowest priority.
+func (t *Toolkit) getIcons(name ToolName, cfg *toolConfig) []mcp.Icon {
+	// Per-registration override (highest priority)
+	if cfg != nil && cfg.icons != nil {
+		return cfg.icons
+	}
+
+	// Toolkit-level override (medium priority)
+	if icons, ok := t.icons[name]; ok {
+		return icons
+	}
+
+	// Default icons (lowest priority)
+	return defaultIcons
+}

--- a/pkg/tools/icons_test.go
+++ b/pkg/tools/icons_test.go
@@ -1,0 +1,90 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestDefaultIcons(t *testing.T) {
+	icons := DefaultIcons()
+	if len(icons) != 1 {
+		t.Fatalf("expected 1 default icon, got %d", len(icons))
+	}
+	if icons[0].Source == "" {
+		t.Error("default icon source should not be empty")
+	}
+	if icons[0].MIMEType != "image/svg+xml" {
+		t.Errorf("expected MIME type image/svg+xml, got %s", icons[0].MIMEType)
+	}
+}
+
+func TestGetIcons_DefaultPriority(t *testing.T) {
+	tk := newBaseToolkit(DefaultConfig())
+	icons := tk.getIcons(ToolQuery, nil)
+	if len(icons) != 1 {
+		t.Fatalf("expected 1 icon, got %d", len(icons))
+	}
+	if icons[0].Source != defaultIcons[0].Source {
+		t.Errorf("expected default icon source, got %s", icons[0].Source)
+	}
+}
+
+func TestGetIcons_ToolkitOverride(t *testing.T) {
+	tk := newBaseToolkit(DefaultConfig())
+	customIcons := []mcp.Icon{{Source: "https://example.com/custom.svg", MIMEType: "image/svg+xml"}}
+	tk.icons[ToolQuery] = customIcons
+
+	// ToolQuery should get the override
+	icons := tk.getIcons(ToolQuery, nil)
+	if len(icons) != 1 {
+		t.Fatalf("expected 1 icon, got %d", len(icons))
+	}
+	if icons[0].Source != "https://example.com/custom.svg" {
+		t.Errorf("expected custom icon source, got %s", icons[0].Source)
+	}
+
+	// ToolExplain should get the default
+	icons = tk.getIcons(ToolExplain, nil)
+	if icons[0].Source != defaultIcons[0].Source {
+		t.Errorf("expected default icon source for ToolExplain, got %s", icons[0].Source)
+	}
+}
+
+func TestGetIcons_PerRegistrationOverride(t *testing.T) {
+	tk := newBaseToolkit(DefaultConfig())
+	// Set toolkit-level override
+	tk.icons[ToolQuery] = []mcp.Icon{{Source: "https://example.com/toolkit.svg"}}
+
+	// Per-registration should take highest priority
+	cfg := &toolConfig{
+		icons: []mcp.Icon{{Source: "https://example.com/registration.svg"}},
+	}
+	icons := tk.getIcons(ToolQuery, cfg)
+	if len(icons) != 1 {
+		t.Fatalf("expected 1 icon, got %d", len(icons))
+	}
+	if icons[0].Source != "https://example.com/registration.svg" {
+		t.Errorf("expected per-registration icon source, got %s", icons[0].Source)
+	}
+}
+
+func TestGetIcons_NilConfig(t *testing.T) {
+	tk := newBaseToolkit(DefaultConfig())
+	icons := tk.getIcons(ToolQuery, nil)
+	if len(icons) == 0 {
+		t.Fatal("expected default icons, got empty")
+	}
+}
+
+func TestGetIcons_EmptyToolConfig(t *testing.T) {
+	tk := newBaseToolkit(DefaultConfig())
+	cfg := &toolConfig{}
+	icons := tk.getIcons(ToolQuery, cfg)
+	if len(icons) == 0 {
+		t.Fatal("expected default icons, got empty")
+	}
+	if icons[0].Source != defaultIcons[0].Source {
+		t.Errorf("expected default icon, got %s", icons[0].Source)
+	}
+}

--- a/pkg/tools/options.go
+++ b/pkg/tools/options.go
@@ -46,11 +46,31 @@ func WithToolMiddleware(name ToolName, m ToolMiddleware) ToolkitOption {
 	}
 }
 
+// WithIcons sets custom icons for multiple tools at the toolkit level.
+// These override default icons but are themselves overridden by per-registration
+// WithIcon calls.
+//
+// Example:
+//
+//	toolkit := tools.NewToolkit(client, cfg,
+//	    tools.WithIcons(map[tools.ToolName][]mcp.Icon{
+//	        tools.ToolQuery: {{Source: "https://example.com/query.svg", MIMEType: "image/svg+xml"}},
+//	    }),
+//	)
+func WithIcons(icons map[ToolName][]mcp.Icon) ToolkitOption {
+	return func(t *Toolkit) {
+		for name, ic := range icons {
+			t.icons[name] = ic
+		}
+	}
+}
+
 // toolConfig holds per-registration configuration for a tool.
 type toolConfig struct {
 	middlewares []ToolMiddleware
 	description *string
 	annotations *mcp.ToolAnnotations
+	icons       []mcp.Icon
 }
 
 // ToolOption configures a single tool during registration.
@@ -129,6 +149,20 @@ func WithAnnotations(anns map[ToolName]*mcp.ToolAnnotations) ToolkitOption {
 func WithAnnotation(ann *mcp.ToolAnnotations) ToolOption {
 	return func(tc *toolConfig) {
 		tc.annotations = ann
+	}
+}
+
+// WithIcon sets custom icons for a single tool registration.
+// Use with RegisterWith for per-registration icon override.
+//
+// Example:
+//
+//	toolkit.RegisterWith(server, tools.ToolQuery,
+//	    tools.WithIcon([]mcp.Icon{{Source: "https://example.com/query.svg", MIMEType: "image/svg+xml"}}),
+//	)
+func WithIcon(icons []mcp.Icon) ToolOption {
+	return func(tc *toolConfig) {
+		tc.icons = icons
 	}
 }
 

--- a/pkg/tools/options_test.go
+++ b/pkg/tools/options_test.go
@@ -303,6 +303,64 @@ func TestWithAnnotations_Merge(t *testing.T) {
 	}
 }
 
+func TestWithIcon(t *testing.T) {
+	cfg := &toolConfig{}
+	icons := []mcp.Icon{{Source: "https://example.com/icon.svg", MIMEType: "image/svg+xml"}}
+	opt := WithIcon(icons)
+	opt(cfg)
+
+	if len(cfg.icons) != 1 {
+		t.Fatalf("expected 1 icon, got %d", len(cfg.icons))
+	}
+	if cfg.icons[0].Source != "https://example.com/icon.svg" {
+		t.Errorf("expected custom icon source, got %s", cfg.icons[0].Source)
+	}
+}
+
+func TestWithIcons(t *testing.T) {
+	clientCfg := client.Config{
+		Host: "localhost",
+		User: "test",
+	}
+	trinoClient := client.NewWithDB(nil, clientCfg)
+
+	icons := map[ToolName][]mcp.Icon{
+		ToolQuery: {{Source: "https://example.com/query.svg", MIMEType: "image/svg+xml"}},
+	}
+	toolkit := NewToolkit(trinoClient, DefaultConfig(), WithIcons(icons))
+
+	if len(toolkit.icons[ToolQuery]) != 1 {
+		t.Fatalf("expected 1 icon for ToolQuery, got %d", len(toolkit.icons[ToolQuery]))
+	}
+	if toolkit.icons[ToolQuery][0].Source != "https://example.com/query.svg" {
+		t.Errorf("expected custom icon source, got %s", toolkit.icons[ToolQuery][0].Source)
+	}
+}
+
+func TestWithIcons_Merge(t *testing.T) {
+	clientCfg := client.Config{
+		Host: "localhost",
+		User: "test",
+	}
+	trinoClient := client.NewWithDB(nil, clientCfg)
+
+	toolkit := NewToolkit(trinoClient, DefaultConfig(),
+		WithIcons(map[ToolName][]mcp.Icon{
+			ToolQuery: {{Source: "https://example.com/query.svg"}},
+		}),
+		WithIcons(map[ToolName][]mcp.Icon{
+			ToolExplain: {{Source: "https://example.com/explain.svg"}},
+		}),
+	)
+
+	if len(toolkit.icons[ToolQuery]) != 1 {
+		t.Error("expected ToolQuery icon to survive merge")
+	}
+	if len(toolkit.icons[ToolExplain]) != 1 {
+		t.Error("expected ToolExplain icon from second call")
+	}
+}
+
 func TestWithSemanticCache_WithoutProvider(t *testing.T) {
 	cfg := client.Config{
 		Host: "localhost",

--- a/pkg/tools/query.go
+++ b/pkg/tools/query.go
@@ -51,6 +51,7 @@ func (t *Toolkit) registerQueryTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolQuery),
 		Description: t.getDescription(ToolQuery, cfg),
 		Annotations: t.getAnnotations(ToolQuery, cfg),
+		Icons:       t.getIcons(ToolQuery, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input QueryInput) (*mcp.CallToolResult, *QueryOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*QueryOutput); ok {

--- a/pkg/tools/schema.go
+++ b/pkg/tools/schema.go
@@ -40,6 +40,7 @@ func (t *Toolkit) registerListCatalogsTool(server *mcp.Server, cfg *toolConfig) 
 		Name:        string(ToolListCatalogs),
 		Description: t.getDescription(ToolListCatalogs, cfg),
 		Annotations: t.getAnnotations(ToolListCatalogs, cfg),
+		Icons:       t.getIcons(ToolListCatalogs, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListCatalogsInput) (*mcp.CallToolResult, *ListCatalogsOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*ListCatalogsOutput); ok {
@@ -112,6 +113,7 @@ func (t *Toolkit) registerListSchemasTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolListSchemas),
 		Description: t.getDescription(ToolListSchemas, cfg),
 		Annotations: t.getAnnotations(ToolListSchemas, cfg),
+		Icons:       t.getIcons(ToolListSchemas, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListSchemasInput) (*mcp.CallToolResult, *ListSchemasOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*ListSchemasOutput); ok {
@@ -193,6 +195,7 @@ func (t *Toolkit) registerListTablesTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolListTables),
 		Description: t.getDescription(ToolListTables, cfg),
 		Annotations: t.getAnnotations(ToolListTables, cfg),
+		Icons:       t.getIcons(ToolListTables, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListTablesInput) (*mcp.CallToolResult, *ListTablesOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*ListTablesOutput); ok {
@@ -302,6 +305,7 @@ func (t *Toolkit) registerDescribeTableTool(server *mcp.Server, cfg *toolConfig)
 		Name:        string(ToolDescribeTable),
 		Description: t.getDescription(ToolDescribeTable, cfg),
 		Annotations: t.getAnnotations(ToolDescribeTable, cfg),
+		Icons:       t.getIcons(ToolDescribeTable, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input DescribeTableInput) (*mcp.CallToolResult, *DescribeTableOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*DescribeTableOutput); ok {

--- a/pkg/tools/toolkit.go
+++ b/pkg/tools/toolkit.go
@@ -60,6 +60,9 @@ type Toolkit struct {
 	// Annotation overrides (toolkit-level)
 	annotations map[ToolName]*mcp.ToolAnnotations
 
+	// Icon overrides (toolkit-level)
+	icons map[ToolName][]mcp.Icon
+
 	// Internal tracking
 	registeredTools map[ToolName]bool
 }
@@ -98,6 +101,7 @@ func newBaseToolkit(cfg Config) *Toolkit {
 		toolMiddlewares: make(map[ToolName][]ToolMiddleware),
 		descriptions:    make(map[ToolName]string),
 		annotations:     make(map[ToolName]*mcp.ToolAnnotations),
+		icons:           make(map[ToolName][]mcp.Icon),
 		registeredTools: make(map[ToolName]bool),
 	}
 }


### PR DESCRIPTION
## Summary

- Add `Icons` field to all 7 tool registrations (`trino_query`, `trino_explain`, `trino_list_catalogs`, `trino_list_schemas`, `trino_list_tables`, `trino_describe_table`, `trino_list_connections`)
- Implement 3-level icon priority chain: per-registration override → toolkit-level override → built-in default (same pattern as descriptions and annotations)
- New `WithIcons()` toolkit option and `WithIcon()` tool option for consumers to customize icons
- Default icon is a Trino-branded SVG hosted in the `icons/` directory

## Details

The MCP SDK's `mcp.Tool` struct includes an `Icons []mcp.Icon` field that surfaces visual metadata in `tools/list` responses. Clients that support icons (e.g., Claude Desktop) render these alongside tool names.

The resolution chain follows the same pattern used by `getDescription()` and `getAnnotations()`:

1. **Per-registration** (`WithIcon()` tool option) — highest priority
2. **Toolkit-level** (`WithIcons()` toolkit option) — override specific tools
3. **Built-in default** — all tools get the Trino SVG

This allows downstream consumers (e.g., `mcp-data-platform`) to override icons via their own configuration layer.

## Files

| File | Change |
|------|--------|
| `icons/trino.svg` | New — default Trino tool icon |
| `pkg/tools/icons.go` | New — `getIcons()` helper + default icon constant |
| `pkg/tools/icons_test.go` | New — tests for all priority levels |
| `pkg/tools/toolkit.go` | Add `icons` map field to Toolkit struct |
| `pkg/tools/options.go` | Add `WithIcons()` toolkit option, `WithIcon()` tool option, `icons` field to `toolConfig` |
| `pkg/tools/options_test.go` | Tests for new options |
| `pkg/tools/query.go` | Add `Icons: t.getIcons(...)` |
| `pkg/tools/explain.go` | Add `Icons: t.getIcons(...)` |
| `pkg/tools/connections.go` | Add `Icons: t.getIcons(...)` |
| `pkg/tools/schema.go` | Add `Icons: t.getIcons(...)` (4 tools) |

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] Lint clean (`golangci-lint run ./...` — 0 issues)
- [x] New unit tests cover default icons, toolkit-level override, per-registration override, nil config, and empty config
- [ ] Manual: connect a client, call `tools/list`, verify icons appear on all 7 tool entries