### PR TITLE
feat: split trino_query into read-only query and unrestricted execute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,8 @@ toolkit.RegisterAll(yourMCPServer)
 
 | Tool | Description |
 |------|-------------|
-| `trino_query` | Execute SQL, returns JSON/CSV/markdown |
+| `trino_query` | Execute read-only SQL (SELECT/SHOW/DESCRIBE), returns JSON/CSV/markdown |
+| `trino_execute` | Execute any SQL including write ops (INSERT/UPDATE/DELETE/CREATE/DROP) |
 | `trino_explain` | Get execution plan |
 | `trino_list_catalogs` | List available catalogs |
 | `trino_list_schemas` | List schemas in catalog |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ mcp-trino
 
 | Tool | Description |
 |------|-------------|
-| `trino_query` | Execute SQL queries with limit/timeout control |
+| `trino_query` | Execute read-only SQL queries (SELECT, SHOW, DESCRIBE) with limit/timeout control |
+| `trino_execute` | Execute any SQL including write operations (INSERT, UPDATE, DELETE, CREATE, DROP) |
 | `trino_explain` | Get execution plans (logical/distributed/io/validate) |
 | `trino_list_catalogs` | List available catalogs |
 | `trino_list_schemas` | List schemas in a catalog |

--- a/pkg/extensions/readonly.go
+++ b/pkg/extensions/readonly.go
@@ -48,8 +48,8 @@ func NewReadOnlyInterceptor() *ReadOnlyInterceptor {
 
 // Intercept checks if the SQL is a modification statement and blocks it.
 func (ri *ReadOnlyInterceptor) Intercept(_ context.Context, sql string, toolName tools.ToolName) (string, error) {
-	// Only check query and explain tools
-	if toolName != tools.ToolQuery && toolName != tools.ToolExplain {
+	// Only check SQL-executing tools
+	if toolName != tools.ToolQuery && toolName != tools.ToolExecute && toolName != tools.ToolExplain {
 		return sql, nil
 	}
 

--- a/pkg/tools/annotations.go
+++ b/pkg/tools/annotations.go
@@ -15,7 +15,13 @@ func boolPtr(b bool) *bool {
 //   - OpenWorldHint (*bool, default true): tool interacts with external entities
 var defaultAnnotations = map[ToolName]*mcp.ToolAnnotations{
 	ToolQuery: {
+		ReadOnlyHint:    true,
+		IdempotentHint:  true,
 		DestructiveHint: boolPtr(false),
+		OpenWorldHint:   boolPtr(false),
+	},
+	ToolExecute: {
+		DestructiveHint: boolPtr(true),
 		OpenWorldHint:   boolPtr(false),
 	},
 	ToolExplain: {

--- a/pkg/tools/annotations_test.go
+++ b/pkg/tools/annotations_test.go
@@ -12,6 +12,7 @@ func TestDefaultAnnotations(t *testing.T) {
 		wantNil bool
 	}{
 		{ToolQuery, false},
+		{ToolExecute, false},
 		{ToolExplain, false},
 		{ToolListCatalogs, false},
 		{ToolListSchemas, false},
@@ -44,6 +45,7 @@ func TestDefaultAnnotations_AllToolsCovered(t *testing.T) {
 
 func TestDefaultAnnotations_ReadOnlyTools(t *testing.T) {
 	readOnlyTools := []ToolName{
+		ToolQuery,
 		ToolExplain,
 		ToolListCatalogs,
 		ToolListSchemas,
@@ -70,14 +72,30 @@ func TestDefaultAnnotations_ReadOnlyTools(t *testing.T) {
 
 func TestDefaultAnnotations_QueryTool(t *testing.T) {
 	ann := DefaultAnnotations(ToolQuery)
-	if ann.ReadOnlyHint {
-		t.Error("expected ReadOnlyHint=false for trino_query")
+	if !ann.ReadOnlyHint {
+		t.Error("expected ReadOnlyHint=true for trino_query (read-only tool)")
+	}
+	if !ann.IdempotentHint {
+		t.Error("expected IdempotentHint=true for trino_query")
 	}
 	if ann.DestructiveHint == nil || *ann.DestructiveHint {
 		t.Error("expected DestructiveHint=false for trino_query")
 	}
 	if ann.OpenWorldHint == nil || *ann.OpenWorldHint {
 		t.Error("expected OpenWorldHint=false for trino_query")
+	}
+}
+
+func TestDefaultAnnotations_ExecuteTool(t *testing.T) {
+	ann := DefaultAnnotations(ToolExecute)
+	if ann.ReadOnlyHint {
+		t.Error("expected ReadOnlyHint=false for trino_execute")
+	}
+	if ann.DestructiveHint == nil || !*ann.DestructiveHint {
+		t.Error("expected DestructiveHint=true for trino_execute")
+	}
+	if ann.OpenWorldHint == nil || *ann.OpenWorldHint {
+		t.Error("expected OpenWorldHint=false for trino_execute")
 	}
 }
 

--- a/pkg/tools/descriptions.go
+++ b/pkg/tools/descriptions.go
@@ -3,10 +3,18 @@ package tools
 // defaultDescriptions holds the default description for each built-in tool.
 // These are used when no override is provided via WithDescription or WithDescriptions.
 var defaultDescriptions = map[ToolName]string{
-	ToolQuery: "Execute a SELECT query against Trino and return results. Use the table path format " +
-		"catalog.schema.table. Results are limited to prevent excessive data transfer — use " +
-		"the limit parameter to control result size. For large tables, always include WHERE " +
-		"clauses to filter results. Consider using trino_explain first for expensive queries.",
+	ToolQuery: "Execute a read-only SQL query against Trino and return results. " +
+		"Only SELECT, SHOW, DESCRIBE, EXPLAIN, and WITH statements are allowed. " +
+		"Use the table path format catalog.schema.table. Results are limited to prevent " +
+		"excessive data transfer — use the limit parameter to control result size. " +
+		"For large tables, always include WHERE clauses to filter results. " +
+		"Consider using trino_explain first for expensive queries. " +
+		"For write operations (INSERT, CREATE, etc.), use trino_execute instead.",
+
+	ToolExecute: "Execute a SQL statement against Trino, including write operations " +
+		"(INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, etc.). Returns affected row " +
+		"counts or query results. Use trino_query for read-only SELECT queries. " +
+		"This tool should be used when you need to modify data or schema.",
 
 	ToolExplain: "Get the execution plan for a SQL query to understand performance characteristics " +
 		"before running expensive queries. Use this when querying large tables (millions of " +

--- a/pkg/tools/descriptions_test.go
+++ b/pkg/tools/descriptions_test.go
@@ -8,6 +8,7 @@ func TestDefaultDescription(t *testing.T) {
 		wantNon bool // expect non-empty
 	}{
 		{ToolQuery, true},
+		{ToolExecute, true},
 		{ToolExplain, true},
 		{ToolListCatalogs, true},
 		{ToolListSchemas, true},

--- a/pkg/tools/execute.go
+++ b/pkg/tools/execute.go
@@ -1,0 +1,150 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-trino/pkg/client"
+)
+
+// ExecuteInput defines the input for the trino_execute tool.
+type ExecuteInput struct {
+	// SQL is the SQL statement to execute (including write operations).
+	SQL string `json:"sql" jsonschema_description:"The SQL statement to execute (SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, etc.)"`
+
+	// Limit is the maximum number of rows to return. Default: 1000, Max: 10000.
+	Limit int `json:"limit,omitempty" jsonschema_description:"Maximum rows to return (default: 1000, max: 10000)"`
+
+	// TimeoutSeconds is the query timeout in seconds. Default: 120, Max: 300.
+	TimeoutSeconds int `json:"timeout_seconds,omitempty" jsonschema_description:"Query timeout in seconds (default: 120, max: 300)"`
+
+	// Format is the output format: json (default), csv, or markdown.
+	Format string `json:"format,omitempty" jsonschema_description:"Output format: json, csv, or markdown (default: json)"`
+
+	// Connection is the named connection to use. Empty uses the default connection.
+	// Use trino_list_connections to see available connections.
+	Connection string `json:"connection,omitempty" jsonschema_description:"Named connection to use (see trino_list_connections)"`
+}
+
+// registerExecuteTool adds the trino_execute tool to the server.
+//
+//nolint:dupl // Each tool registration requires distinct types for type-safe handlers.
+func (t *Toolkit) registerExecuteTool(server *mcp.Server, cfg *toolConfig) {
+	// Create the base handler
+	baseHandler := func(ctx context.Context, req *mcp.CallToolRequest, input any) (*mcp.CallToolResult, any, error) {
+		executeInput, ok := input.(ExecuteInput)
+		if !ok {
+			return ErrorResult("internal error: invalid input type"), nil, nil
+		}
+		return t.handleExecute(ctx, req, executeInput)
+	}
+
+	// Wrap with middleware if configured
+	wrappedHandler := t.wrapHandler(ToolExecute, baseHandler, cfg)
+
+	// Register with MCP using typed handler that calls wrapped handler
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        string(ToolExecute),
+		Description: t.getDescription(ToolExecute, cfg),
+		Annotations: t.getAnnotations(ToolExecute, cfg),
+		Icons:       t.getIcons(ToolExecute, cfg),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input ExecuteInput) (*mcp.CallToolResult, *QueryOutput, error) {
+		result, out, err := wrappedHandler(ctx, req, input)
+		if typed, ok := out.(*QueryOutput); ok {
+			return result, typed, err
+		}
+		return result, nil, err
+	})
+}
+
+func (t *Toolkit) handleExecute(ctx context.Context, _ *mcp.CallToolRequest, input ExecuteInput) (*mcp.CallToolResult, any, error) {
+	// Validate SQL is provided
+	if input.SQL == "" {
+		return ErrorResult("sql parameter is required"), nil, nil
+	}
+
+	// Apply query interceptors (no read-only enforcement — that's the point of trino_execute)
+	sql, err := t.InterceptSQL(ctx, input.SQL, ToolExecute)
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("Query rejected: %v", err)), nil, nil
+	}
+
+	// Apply limits
+	limit := input.Limit
+	if limit <= 0 {
+		limit = t.config.DefaultLimit
+	}
+	if limit > t.config.MaxLimit {
+		limit = t.config.MaxLimit
+	}
+
+	// Apply timeout
+	timeout := time.Duration(input.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = t.config.DefaultTimeout
+	}
+	if timeout > t.config.MaxTimeout {
+		timeout = t.config.MaxTimeout
+	}
+
+	// Get client for the specified connection
+	trinoClient, err := t.getClient(input.Connection)
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("Connection error: %v", err)), nil, nil
+	}
+
+	// Send progress notification: executing statement
+	notifier := GetProgressNotifier(ctx)
+	notifyProgress(ctx, notifier, 0, 3, "Executing statement...")
+
+	// Execute query
+	opts := client.QueryOptions{
+		Limit:   limit,
+		Timeout: timeout,
+	}
+
+	result, err := trinoClient.Query(ctx, sql, opts)
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("Execution failed: %v", err)), nil, nil
+	}
+
+	// Send progress notification: formatting results
+	notifyProgress(ctx, notifier, 1, 3,
+		fmt.Sprintf("Statement returned %d rows, formatting...", result.Stats.RowCount))
+
+	// Format output
+	format := input.Format
+	if format == "" {
+		format = "json"
+	}
+
+	var output string
+	switch format {
+	case "csv":
+		output = formatCSV(result)
+	case "markdown":
+		output = formatMarkdown(result)
+	default:
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return ErrorResult(fmt.Sprintf("Failed to marshal result: %v", err)), nil, nil
+		}
+		output = string(data)
+	}
+
+	// Send progress notification: complete
+	notifyProgress(ctx, notifier, 2, 3, "Execution complete")
+
+	// Build structured output (reuse QueryOutput — same result shape)
+	queryOutput := buildQueryOutput(result)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: output},
+		},
+	}, &queryOutput, nil
+}

--- a/pkg/tools/execute_test.go
+++ b/pkg/tools/execute_test.go
@@ -1,0 +1,59 @@
+package tools
+
+import "testing"
+
+func TestIsWriteSQL(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		isWrite bool
+	}{
+		// Write operations
+		{"INSERT", "INSERT INTO users VALUES (1, 'Alice')", true},
+		{"UPDATE", "UPDATE users SET name = 'Bob'", true},
+		{"DELETE", "DELETE FROM users WHERE id = 1", true},
+		{"DROP", "DROP TABLE users", true},
+		{"CREATE", "CREATE TABLE new_table (id INT)", true},
+		{"ALTER", "ALTER TABLE users ADD COLUMN email VARCHAR", true},
+		{"TRUNCATE", "TRUNCATE TABLE users", true},
+		{"GRANT", "GRANT SELECT ON users TO analyst", true},
+		{"REVOKE", "REVOKE SELECT ON users FROM analyst", true},
+		{"MERGE", "MERGE INTO target USING source ON t.id = s.id", true},
+		{"CALL", "CALL system.sync_partition_metadata('catalog', 'schema', 'table')", true},
+		{"EXECUTE", "EXECUTE my_prepared_statement", true},
+
+		// Case insensitive
+		{"insert lowercase", "insert into users values (1)", true},
+		{"Insert mixed", "Insert Into users VALUES (1)", true},
+
+		// Leading whitespace
+		{"leading spaces", "   INSERT INTO users VALUES (1)", true},
+		{"leading tab", "\tDROP TABLE users", true},
+
+		// SQL comments before keyword
+		{"line comment", "-- comment\nINSERT INTO users VALUES (1)", true},
+		{"block comment", "/* comment */INSERT INTO users VALUES (1)", true},
+
+		// Read operations
+		{"SELECT", "SELECT * FROM users", false},
+		{"select lowercase", "select id from users", false},
+		{"SHOW", "SHOW TABLES", false},
+		{"DESCRIBE", "DESCRIBE users", false},
+		{"EXPLAIN", "EXPLAIN SELECT * FROM users", false},
+		{"WITH CTE", "WITH cte AS (SELECT 1) SELECT * FROM cte", false},
+
+		// Edge cases
+		{"empty", "", false},
+		{"whitespace only", "   ", false},
+		{"SELECT with INSERT in value", "SELECT * FROM users WHERE name = 'INSERT'", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsWriteSQL(tt.sql)
+			if got != tt.isWrite {
+				t.Errorf("IsWriteSQL(%q) = %v, want %v", tt.sql, got, tt.isWrite)
+			}
+		})
+	}
+}

--- a/pkg/tools/names.go
+++ b/pkg/tools/names.go
@@ -6,6 +6,7 @@ type ToolName string
 // Built-in tool names.
 const (
 	ToolQuery           ToolName = "trino_query"
+	ToolExecute         ToolName = "trino_execute"
 	ToolExplain         ToolName = "trino_explain"
 	ToolListCatalogs    ToolName = "trino_list_catalogs"
 	ToolListSchemas     ToolName = "trino_list_schemas"
@@ -18,6 +19,7 @@ const (
 func AllTools() []ToolName {
 	return []ToolName{
 		ToolQuery,
+		ToolExecute,
 		ToolExplain,
 		ToolListCatalogs,
 		ToolListSchemas,
@@ -32,6 +34,7 @@ func AllTools() []ToolName {
 func QueryTools() []ToolName {
 	return []ToolName{
 		ToolQuery,
+		ToolExecute,
 		ToolExplain,
 	}
 }

--- a/pkg/tools/names_test.go
+++ b/pkg/tools/names_test.go
@@ -10,6 +10,7 @@ func TestToolName_String(t *testing.T) {
 		expected string
 	}{
 		{ToolQuery, "trino_query"},
+		{ToolExecute, "trino_execute"},
 		{ToolExplain, "trino_explain"},
 		{ToolListCatalogs, "trino_list_catalogs"},
 		{ToolListSchemas, "trino_list_schemas"},
@@ -30,13 +31,14 @@ func TestToolName_String(t *testing.T) {
 func TestAllTools(t *testing.T) {
 	tools := AllTools()
 
-	if len(tools) != 7 {
-		t.Errorf("expected 7 tools, got %d", len(tools))
+	if len(tools) != 8 {
+		t.Errorf("expected 8 tools, got %d", len(tools))
 	}
 
 	// Verify all expected tools are present
 	expected := map[ToolName]bool{
 		ToolQuery:           false,
+		ToolExecute:         false,
 		ToolExplain:         false,
 		ToolListCatalogs:    false,
 		ToolListSchemas:     false,
@@ -62,18 +64,21 @@ func TestAllTools(t *testing.T) {
 func TestQueryTools(t *testing.T) {
 	tools := QueryTools()
 
-	if len(tools) != 2 {
-		t.Errorf("expected 2 query tools, got %d", len(tools))
+	if len(tools) != 3 {
+		t.Errorf("expected 3 query tools, got %d", len(tools))
 	}
 
-	// Should contain ToolQuery and ToolExplain
+	// Should contain ToolQuery, ToolExecute, and ToolExplain
 	hasQuery := false
+	hasExecute := false
 	hasExplain := false
 
 	for _, tool := range tools {
 		switch tool {
 		case ToolQuery:
 			hasQuery = true
+		case ToolExecute:
+			hasExecute = true
 		case ToolExplain:
 			hasExplain = true
 		default:
@@ -83,6 +88,9 @@ func TestQueryTools(t *testing.T) {
 
 	if !hasQuery {
 		t.Error("missing ToolQuery")
+	}
+	if !hasExecute {
+		t.Error("missing ToolExecute")
 	}
 	if !hasExplain {
 		t.Error("missing ToolExplain")

--- a/pkg/tools/options.go
+++ b/pkg/tools/options.go
@@ -20,7 +20,7 @@ func WithMiddleware(m ToolMiddleware) ToolkitOption {
 
 // WithQueryInterceptor adds a query interceptor for SQL tools.
 // Interceptors are executed in the order added.
-// Only applies to ToolQuery and ToolExplain.
+// Only applies to ToolQuery, ToolExecute, and ToolExplain.
 func WithQueryInterceptor(i QueryInterceptor) ToolkitOption {
 	return func(t *Toolkit) {
 		t.interceptors = append(t.interceptors, i)

--- a/pkg/tools/toolkit.go
+++ b/pkg/tools/toolkit.go
@@ -161,6 +161,8 @@ func (t *Toolkit) registerTool(server *mcp.Server, name ToolName, cfg *toolConfi
 	switch name {
 	case ToolQuery:
 		t.registerQueryTool(server, cfg)
+	case ToolExecute:
+		t.registerExecuteTool(server, cfg)
 	case ToolExplain:
 		t.registerExplainTool(server, cfg)
 	case ToolListCatalogs:


### PR DESCRIPTION
## Summary

`trino_query` accepted both `SELECT` and `INSERT INTO`, making it the only tool with ambiguous read-write semantics. MCP clients couldn't auto-approve it since it could execute destructive writes.

This PR splits it into two tools:

| Tool | SQL Allowed | `ReadOnlyHint` | `DestructiveHint` | Client Behavior |
|------|-------------|----------------|-------------------|-----------------|
| `trino_query` | SELECT, SHOW, DESCRIBE, EXPLAIN, WITH | `true` | `false` | Auto-approvable |
| `trino_execute` | All SQL (INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, etc.) | — | `true` | Prompts for confirmation |

## Design

- **`trino_query`** enforces read-only at the handler level via `IsWriteSQL()` — a regex-based check that detects write keywords (INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, TRUNCATE, GRANT, REVOKE, MERGE, CALL, EXECUTE) including through leading whitespace and SQL comments. Runs before interceptors, cannot be bypassed.

- **`trino_execute`** uses identical execution logic (same `client.Query()`, same formatting, same interceptor chain) but without the read-only check.

- **Instance-level `ReadOnlyInterceptor`** (extensions) now also checks `ToolExecute`, so `MCP_TRINO_EXT_READONLY=true` blocks writes on both tools.

- **`IsWriteSQL()`** is exported as public API for downstream consumers that need SQL write detection.

## Changes

**New files:**
- `pkg/tools/execute.go` — `trino_execute` handler, `ExecuteInput` type
- `pkg/tools/execute_test.go` — `IsWriteSQL` table-driven tests

**Modified:**
- `pkg/tools/names.go` — Add `ToolExecute`, update `AllTools()`, `QueryTools()`
- `pkg/tools/query.go` — Add `IsWriteSQL()`, `writePattern` regex, read-only enforcement in `handleQuery`
- `pkg/tools/annotations.go` — `ToolQuery` gets `ReadOnlyHint: true`, `ToolExecute` gets `DestructiveHint: true`
- `pkg/tools/descriptions.go` — Updated `ToolQuery` description, added `ToolExecute` description
- `pkg/tools/toolkit.go` — Register `ToolExecute` in `registerTool()` switch
- `pkg/tools/options.go` — Updated comment for `WithQueryInterceptor`
- `pkg/extensions/readonly.go` — Check `ToolExecute` in addition to `ToolQuery`/`ToolExplain`
- `README.md`, `CLAUDE.md` — Updated tools tables

## Breaking Change

`trino_query` now rejects write SQL with an error message directing users to `trino_execute`.

## Test Plan

- [x] `IsWriteSQL` — table-driven tests covering all write keywords, case insensitivity, leading whitespace, SQL comments, and read operations
- [x] `handleQuery` read-only enforcement — 13 write SQL variants rejected, 6 read SQL variants allowed
- [x] `handleExecute` — success, error, interceptor, CSV/markdown formats, connection error, empty SQL
- [x] MCP dispatch integration test — full `mcp.Server` + `InMemoryTransport` + `CallTool` verifying `trino_query` rejects INSERT, allows SELECT, and `trino_execute` allows INSERT
- [x] `ReadOnlyInterceptor` blocks writes on `ToolExecute` when enabled
- [x] All existing tests updated and passing
- [x] Coverage: `IsWriteSQL` 100%, `handleExecute` 89.7%, `handleQuery` 92.7%, `registerExecuteTool` 81.8%
- [x] `golangci-lint`, `gosec` clean