### PR TITLE
feat: Tool.Title support, OpenWorldHint correction, OutputSchema notes

### DIFF
--- a/pkg/tools/annotations.go
+++ b/pkg/tools/annotations.go
@@ -13,46 +13,50 @@ func boolPtr(b bool) *bool {
 //   - DestructiveHint (*bool, default true): tool may destructively update
 //   - IdempotentHint (bool, default false): repeated calls produce same result
 //   - OpenWorldHint (*bool, default true): tool interacts with external entities
+//
+// All Trino tools communicate with an external Trino cluster, so OpenWorldHint
+// is true for all tools — this correctly signals to MCP clients that these
+// tools interact with entities outside the server's direct control.
 var defaultAnnotations = map[ToolName]*mcp.ToolAnnotations{
 	ToolQuery: {
 		ReadOnlyHint:    true,
 		IdempotentHint:  true,
 		DestructiveHint: boolPtr(false),
-		OpenWorldHint:   boolPtr(false),
+		OpenWorldHint:   boolPtr(true),
 	},
 	ToolExecute: {
 		DestructiveHint: boolPtr(true),
-		OpenWorldHint:   boolPtr(false),
+		OpenWorldHint:   boolPtr(true),
 	},
 	ToolExplain: {
 		ReadOnlyHint:   true,
 		IdempotentHint: true,
-		OpenWorldHint:  boolPtr(false),
+		OpenWorldHint:  boolPtr(true),
 	},
 	ToolListCatalogs: {
 		ReadOnlyHint:   true,
 		IdempotentHint: true,
-		OpenWorldHint:  boolPtr(false),
+		OpenWorldHint:  boolPtr(true),
 	},
 	ToolListSchemas: {
 		ReadOnlyHint:   true,
 		IdempotentHint: true,
-		OpenWorldHint:  boolPtr(false),
+		OpenWorldHint:  boolPtr(true),
 	},
 	ToolListTables: {
 		ReadOnlyHint:   true,
 		IdempotentHint: true,
-		OpenWorldHint:  boolPtr(false),
+		OpenWorldHint:  boolPtr(true),
 	},
 	ToolDescribeTable: {
 		ReadOnlyHint:   true,
 		IdempotentHint: true,
-		OpenWorldHint:  boolPtr(false),
+		OpenWorldHint:  boolPtr(true),
 	},
 	ToolListConnections: {
 		ReadOnlyHint:   true,
 		IdempotentHint: true,
-		OpenWorldHint:  boolPtr(false),
+		OpenWorldHint:  boolPtr(true),
 	},
 }
 

--- a/pkg/tools/annotations_test.go
+++ b/pkg/tools/annotations_test.go
@@ -63,8 +63,8 @@ func TestDefaultAnnotations_ReadOnlyTools(t *testing.T) {
 			if !ann.IdempotentHint {
 				t.Errorf("expected IdempotentHint=true for %s", name)
 			}
-			if ann.OpenWorldHint == nil || *ann.OpenWorldHint {
-				t.Errorf("expected OpenWorldHint=false for %s", name)
+			if ann.OpenWorldHint == nil || !*ann.OpenWorldHint {
+				t.Errorf("expected OpenWorldHint=true for %s", name)
 			}
 		})
 	}
@@ -81,8 +81,8 @@ func TestDefaultAnnotations_QueryTool(t *testing.T) {
 	if ann.DestructiveHint == nil || *ann.DestructiveHint {
 		t.Error("expected DestructiveHint=false for trino_query")
 	}
-	if ann.OpenWorldHint == nil || *ann.OpenWorldHint {
-		t.Error("expected OpenWorldHint=false for trino_query")
+	if ann.OpenWorldHint == nil || !*ann.OpenWorldHint {
+		t.Error("expected OpenWorldHint=true for trino_query (connects to external Trino cluster)")
 	}
 }
 
@@ -94,8 +94,22 @@ func TestDefaultAnnotations_ExecuteTool(t *testing.T) {
 	if ann.DestructiveHint == nil || !*ann.DestructiveHint {
 		t.Error("expected DestructiveHint=true for trino_execute")
 	}
-	if ann.OpenWorldHint == nil || *ann.OpenWorldHint {
-		t.Error("expected OpenWorldHint=false for trino_execute")
+	if ann.OpenWorldHint == nil || !*ann.OpenWorldHint {
+		t.Error("expected OpenWorldHint=true for trino_execute (connects to external Trino cluster)")
+	}
+}
+
+func TestDefaultAnnotations_AllToolsOpenWorld(t *testing.T) {
+	for _, name := range AllTools() {
+		t.Run(string(name), func(t *testing.T) {
+			ann := DefaultAnnotations(name)
+			if ann == nil {
+				t.Fatalf("expected non-nil annotations for %s", name)
+			}
+			if ann.OpenWorldHint == nil || !*ann.OpenWorldHint {
+				t.Errorf("expected OpenWorldHint=true for %s (all tools connect to external Trino cluster)", name)
+			}
+		})
 	}
 }
 

--- a/pkg/tools/connections.go
+++ b/pkg/tools/connections.go
@@ -29,6 +29,8 @@ type ConnectionInfoOutput struct {
 }
 
 // registerListConnectionsTool adds the trino_list_connections tool to the server.
+//
+//nolint:dupl // Each tool registration requires distinct types for type-safe handlers.
 func (t *Toolkit) registerListConnectionsTool(server *mcp.Server, cfg *toolConfig) {
 	// Create the base handler
 	baseHandler := func(ctx context.Context, req *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
@@ -41,6 +43,7 @@ func (t *Toolkit) registerListConnectionsTool(server *mcp.Server, cfg *toolConfi
 	// Register with MCP
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        string(ToolListConnections),
+		Title:       t.getTitle(ToolListConnections, cfg),
 		Description: t.getDescription(ToolListConnections, cfg),
 		Annotations: t.getAnnotations(ToolListConnections, cfg),
 		Icons:       t.getIcons(ToolListConnections, cfg),

--- a/pkg/tools/execute.go
+++ b/pkg/tools/execute.go
@@ -49,6 +49,7 @@ func (t *Toolkit) registerExecuteTool(server *mcp.Server, cfg *toolConfig) {
 	// Register with MCP using typed handler that calls wrapped handler
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        string(ToolExecute),
+		Title:       t.getTitle(ToolExecute, cfg),
 		Description: t.getDescription(ToolExecute, cfg),
 		Annotations: t.getAnnotations(ToolExecute, cfg),
 		Icons:       t.getIcons(ToolExecute, cfg),

--- a/pkg/tools/explain.go
+++ b/pkg/tools/explain.go
@@ -41,6 +41,7 @@ func (t *Toolkit) registerExplainTool(server *mcp.Server, cfg *toolConfig) {
 	// Register with MCP using typed handler that calls wrapped handler
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        string(ToolExplain),
+		Title:       t.getTitle(ToolExplain, cfg),
 		Description: t.getDescription(ToolExplain, cfg),
 		Annotations: t.getAnnotations(ToolExplain, cfg),
 		Icons:       t.getIcons(ToolExplain, cfg),

--- a/pkg/tools/options.go
+++ b/pkg/tools/options.go
@@ -46,6 +46,40 @@ func WithToolMiddleware(name ToolName, m ToolMiddleware) ToolkitOption {
 	}
 }
 
+// WithTitle sets a custom human-readable title for a single tool registration.
+// Use with RegisterWith for per-registration title override.
+//
+// Example:
+//
+//	toolkit.RegisterWith(server, tools.ToolQuery,
+//	    tools.WithTitle("Query the Retail Warehouse"),
+//	)
+func WithTitle(title string) ToolOption {
+	return func(tc *toolConfig) {
+		tc.title = &title
+	}
+}
+
+// WithTitles sets custom human-readable titles for multiple tools at the toolkit level.
+// These override default titles but are themselves overridden by per-registration
+// WithTitle calls.
+//
+// Example:
+//
+//	toolkit := tools.NewToolkit(client, cfg,
+//	    tools.WithTitles(map[tools.ToolName]string{
+//	        tools.ToolQuery:   "Query Retail Warehouse",
+//	        tools.ToolExplain: "Check Query Performance",
+//	    }),
+//	)
+func WithTitles(titles map[ToolName]string) ToolkitOption {
+	return func(t *Toolkit) {
+		for name, title := range titles {
+			t.titles[name] = title
+		}
+	}
+}
+
 // WithIcons sets custom icons for multiple tools at the toolkit level.
 // These override default icons but are themselves overridden by per-registration
 // WithIcon calls.
@@ -68,6 +102,7 @@ func WithIcons(icons map[ToolName][]mcp.Icon) ToolkitOption {
 // toolConfig holds per-registration configuration for a tool.
 type toolConfig struct {
 	middlewares []ToolMiddleware
+	title       *string
 	description *string
 	annotations *mcp.ToolAnnotations
 	icons       []mcp.Icon

--- a/pkg/tools/options_test.go
+++ b/pkg/tools/options_test.go
@@ -178,6 +178,65 @@ func TestWithSemanticCache(t *testing.T) {
 	}
 }
 
+func TestWithTitle(t *testing.T) {
+	cfg := &toolConfig{}
+	opt := WithTitle("Custom Title")
+	opt(cfg)
+
+	if cfg.title == nil {
+		t.Fatal("expected title to be set")
+	}
+	if *cfg.title != "Custom Title" {
+		t.Errorf("expected 'Custom Title', got %q", *cfg.title)
+	}
+}
+
+func TestWithTitles(t *testing.T) {
+	clientCfg := client.Config{
+		Host: "localhost",
+		User: "test",
+	}
+	trinoClient := client.NewWithDB(nil, clientCfg)
+
+	titles := map[ToolName]string{
+		ToolQuery:   "Custom Query Title",
+		ToolExplain: "Custom Explain Title",
+	}
+	toolkit := NewToolkit(trinoClient, DefaultConfig(), WithTitles(titles))
+
+	if toolkit.titles[ToolQuery] != "Custom Query Title" {
+		t.Errorf("expected 'Custom Query Title', got %q", toolkit.titles[ToolQuery])
+	}
+	if toolkit.titles[ToolExplain] != "Custom Explain Title" {
+		t.Errorf("expected 'Custom Explain Title', got %q", toolkit.titles[ToolExplain])
+	}
+}
+
+func TestWithTitles_Merge(t *testing.T) {
+	clientCfg := client.Config{
+		Host: "localhost",
+		User: "test",
+	}
+	trinoClient := client.NewWithDB(nil, clientCfg)
+
+	// Apply two rounds of WithTitles — second should merge, not replace
+	toolkit := NewToolkit(trinoClient, DefaultConfig(),
+		WithTitles(map[ToolName]string{
+			ToolQuery: "First Query Title",
+		}),
+		WithTitles(map[ToolName]string{
+			ToolExplain: "Explain Title",
+		}),
+	)
+
+	if toolkit.titles[ToolQuery] != "First Query Title" {
+		t.Errorf("expected 'First Query Title', got %q", toolkit.titles[ToolQuery])
+	}
+	if toolkit.titles[ToolExplain] != "Explain Title" {
+		t.Errorf("expected 'Explain Title', got %q", toolkit.titles[ToolExplain])
+	}
+}
+
 func TestWithDescription(t *testing.T) {
 	cfg := &toolConfig{}
 	opt := WithDescription("Custom description")

--- a/pkg/tools/query.go
+++ b/pkg/tools/query.go
@@ -70,6 +70,7 @@ func (t *Toolkit) registerQueryTool(server *mcp.Server, cfg *toolConfig) {
 	// Register with MCP using typed handler that calls wrapped handler
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        string(ToolQuery),
+		Title:       t.getTitle(ToolQuery, cfg),
 		Description: t.getDescription(ToolQuery, cfg),
 		Annotations: t.getAnnotations(ToolQuery, cfg),
 		Icons:       t.getIcons(ToolQuery, cfg),

--- a/pkg/tools/schema.go
+++ b/pkg/tools/schema.go
@@ -38,6 +38,7 @@ func (t *Toolkit) registerListCatalogsTool(server *mcp.Server, cfg *toolConfig) 
 	// Register with MCP
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        string(ToolListCatalogs),
+		Title:       t.getTitle(ToolListCatalogs, cfg),
 		Description: t.getDescription(ToolListCatalogs, cfg),
 		Annotations: t.getAnnotations(ToolListCatalogs, cfg),
 		Icons:       t.getIcons(ToolListCatalogs, cfg),
@@ -111,6 +112,7 @@ func (t *Toolkit) registerListSchemasTool(server *mcp.Server, cfg *toolConfig) {
 	// Register with MCP
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        string(ToolListSchemas),
+		Title:       t.getTitle(ToolListSchemas, cfg),
 		Description: t.getDescription(ToolListSchemas, cfg),
 		Annotations: t.getAnnotations(ToolListSchemas, cfg),
 		Icons:       t.getIcons(ToolListSchemas, cfg),
@@ -193,6 +195,7 @@ func (t *Toolkit) registerListTablesTool(server *mcp.Server, cfg *toolConfig) {
 	// Register with MCP
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        string(ToolListTables),
+		Title:       t.getTitle(ToolListTables, cfg),
 		Description: t.getDescription(ToolListTables, cfg),
 		Annotations: t.getAnnotations(ToolListTables, cfg),
 		Icons:       t.getIcons(ToolListTables, cfg),
@@ -303,6 +306,7 @@ func (t *Toolkit) registerDescribeTableTool(server *mcp.Server, cfg *toolConfig)
 	// Register with MCP
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        string(ToolDescribeTable),
+		Title:       t.getTitle(ToolDescribeTable, cfg),
 		Description: t.getDescription(ToolDescribeTable, cfg),
 		Annotations: t.getAnnotations(ToolDescribeTable, cfg),
 		Icons:       t.getIcons(ToolDescribeTable, cfg),

--- a/pkg/tools/titles.go
+++ b/pkg/tools/titles.go
@@ -1,0 +1,40 @@
+package tools
+
+// defaultTitles holds the default human-readable display title for each built-in tool.
+// These are shown in MCP clients (e.g. Claude Desktop) as the visible tool name.
+// When no override is provided via WithTitle or WithTitles, these are used.
+var defaultTitles = map[ToolName]string{
+	ToolQuery:           "Execute SQL Query",
+	ToolExecute:         "Execute SQL (Write)",
+	ToolExplain:         "Explain Query Plan",
+	ToolListCatalogs:    "List Catalogs",
+	ToolListSchemas:     "List Schemas",
+	ToolListTables:      "List Tables",
+	ToolDescribeTable:   "Describe Table",
+	ToolListConnections: "List Connections",
+}
+
+// DefaultTitle returns the default human-readable title for a tool.
+// Returns an empty string for unknown tool names.
+func DefaultTitle(name ToolName) string {
+	return defaultTitles[name]
+}
+
+// getTitle resolves the title for a tool using the priority chain:
+// 1. Per-registration override (cfg.title) — highest priority
+// 2. Toolkit-level override (t.titles) — medium priority
+// 3. Default title — lowest priority.
+func (t *Toolkit) getTitle(name ToolName, cfg *toolConfig) string {
+	// Per-registration override (highest priority)
+	if cfg != nil && cfg.title != nil {
+		return *cfg.title
+	}
+
+	// Toolkit-level override (medium priority)
+	if title, ok := t.titles[name]; ok {
+		return title
+	}
+
+	// Default title (lowest priority)
+	return defaultTitles[name]
+}

--- a/pkg/tools/titles_test.go
+++ b/pkg/tools/titles_test.go
@@ -1,0 +1,143 @@
+package tools
+
+import "testing"
+
+func TestDefaultTitle(t *testing.T) {
+	tests := []struct {
+		name    ToolName
+		wantNon bool // expect non-empty
+	}{
+		{ToolQuery, true},
+		{ToolExecute, true},
+		{ToolExplain, true},
+		{ToolListCatalogs, true},
+		{ToolListSchemas, true},
+		{ToolListTables, true},
+		{ToolDescribeTable, true},
+		{ToolListConnections, true},
+		{ToolName("unknown_tool"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.name), func(t *testing.T) {
+			title := DefaultTitle(tt.name)
+			if tt.wantNon && title == "" {
+				t.Errorf("expected non-empty title for %s", tt.name)
+			}
+			if !tt.wantNon && title != "" {
+				t.Errorf("expected empty title for %s, got %q", tt.name, title)
+			}
+		})
+	}
+}
+
+func TestDefaultTitles_AllToolsCovered(t *testing.T) {
+	for _, name := range AllTools() {
+		if DefaultTitle(name) == "" {
+			t.Errorf("tool %s has no default title", name)
+		}
+	}
+}
+
+func TestDefaultTitles_ExpectedValues(t *testing.T) {
+	tests := []struct {
+		name  ToolName
+		title string
+	}{
+		{ToolQuery, "Execute SQL Query"},
+		{ToolExecute, "Execute SQL (Write)"},
+		{ToolExplain, "Explain Query Plan"},
+		{ToolListCatalogs, "List Catalogs"},
+		{ToolListSchemas, "List Schemas"},
+		{ToolListTables, "List Tables"},
+		{ToolDescribeTable, "Describe Table"},
+		{ToolListConnections, "List Connections"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.name), func(t *testing.T) {
+			got := DefaultTitle(tt.name)
+			if got != tt.title {
+				t.Errorf("DefaultTitle(%s) = %q, want %q", tt.name, got, tt.title)
+			}
+		})
+	}
+}
+
+func TestGetTitle_Priority(t *testing.T) {
+	tests := []struct {
+		name          string
+		toolkitTitles map[ToolName]string
+		cfgTitle      *string
+		toolName      ToolName
+		wantTitle     string
+	}{
+		{
+			name:          "default only",
+			toolkitTitles: nil,
+			cfgTitle:      nil,
+			toolName:      ToolQuery,
+			wantTitle:     defaultTitles[ToolQuery],
+		},
+		{
+			name:          "toolkit override",
+			toolkitTitles: map[ToolName]string{ToolQuery: "Toolkit Title"},
+			cfgTitle:      nil,
+			toolName:      ToolQuery,
+			wantTitle:     "Toolkit Title",
+		},
+		{
+			name:          "per-registration override",
+			toolkitTitles: nil,
+			cfgTitle:      strPtr("Per-reg Title"),
+			toolName:      ToolQuery,
+			wantTitle:     "Per-reg Title",
+		},
+		{
+			name:          "per-registration beats toolkit",
+			toolkitTitles: map[ToolName]string{ToolQuery: "Toolkit Title"},
+			cfgTitle:      strPtr("Per-reg Title"),
+			toolName:      ToolQuery,
+			wantTitle:     "Per-reg Title",
+		},
+		{
+			name:          "toolkit override for one tool, default for another",
+			toolkitTitles: map[ToolName]string{ToolQuery: "Custom query title"},
+			cfgTitle:      nil,
+			toolName:      ToolExplain,
+			wantTitle:     defaultTitles[ToolExplain],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tk := &Toolkit{
+				titles: make(map[ToolName]string),
+			}
+			if tt.toolkitTitles != nil {
+				tk.titles = tt.toolkitTitles
+			}
+
+			var cfg *toolConfig
+			if tt.cfgTitle != nil {
+				cfg = &toolConfig{title: tt.cfgTitle}
+			}
+
+			got := tk.getTitle(tt.toolName, cfg)
+			if got != tt.wantTitle {
+				t.Errorf("getTitle() = %q, want %q", got, tt.wantTitle)
+			}
+		})
+	}
+}
+
+func TestGetTitle_NilConfig(t *testing.T) {
+	tk := &Toolkit{
+		titles: make(map[ToolName]string),
+	}
+
+	got := tk.getTitle(ToolQuery, nil)
+	if got != defaultTitles[ToolQuery] {
+		t.Errorf("expected default title, got %q", got)
+	}
+}

--- a/pkg/tools/toolkit.go
+++ b/pkg/tools/toolkit.go
@@ -54,6 +54,9 @@ type Toolkit struct {
 	semanticProvider    semantic.Provider
 	semanticCacheConfig *semantic.CacheConfig
 
+	// Title overrides (toolkit-level)
+	titles map[ToolName]string
+
 	// Description overrides (toolkit-level)
 	descriptions map[ToolName]string
 
@@ -99,6 +102,7 @@ func newBaseToolkit(cfg Config) *Toolkit {
 	return &Toolkit{
 		config:          cfg,
 		toolMiddlewares: make(map[ToolName][]ToolMiddleware),
+		titles:          make(map[ToolName]string),
 		descriptions:    make(map[ToolName]string),
 		annotations:     make(map[ToolName]*mcp.ToolAnnotations),
 		icons:           make(map[ToolName][]mcp.Icon),


### PR DESCRIPTION
Closes #43

## Overview

This PR addresses all three items in #43. Each is described below with the approach taken and why.

---

## Item 1 — `Tool.Title`: default human-readable titles + `WithTitle`/`WithTitles` options

Without `Tool.Title`, MCP clients (e.g. Claude Desktop) display raw machine names like `trino_query` and `trino_list_schemas`. This change adds default titles and the full operator-override stack.

### Default titles

| Tool | Default title |
|---|---|
| `trino_query` | Execute SQL Query |
| `trino_execute` | Execute SQL (Write) |
| `trino_explain` | Explain Query Plan |
| `trino_list_catalogs` | List Catalogs |
| `trino_list_schemas` | List Schemas |
| `trino_list_tables` | List Tables |
| `trino_describe_table` | Describe Table |
| `trino_list_connections` | List Connections |

### New options

```go
// Per-tool at registration time (highest priority)
toolkit.RegisterWith(server, tools.ToolQuery,
    tools.WithTitle("Query the Retail Warehouse"),
)

// Toolkit-level (overrides defaults, overridden by per-registration)
toolkit := tools.NewToolkit(client, cfg,
    tools.WithTitles(map[tools.ToolName]string{
        tools.ToolQuery:   "Query Retail Warehouse",
        tools.ToolExplain: "Check Query Performance",
    }),
)
```

### Implementation

Follows the identical pattern already established by `WithDescription`/`WithDescriptions`, `WithAnnotation`/`WithAnnotations`, and `WithIcon`/`WithIcons`:

- `pkg/tools/titles.go` — `defaultTitles` map, `DefaultTitle()` accessor, `getTitle()` method with 3-level priority chain
- `title *string` added to `toolConfig`
- `titles map[ToolName]string` added to `Toolkit` struct, initialized in `newBaseToolkit`
- `WithTitle(string) ToolOption` and `WithTitles(map[ToolName]string) ToolkitOption` added to `options.go`
- `Title: t.getTitle(name, cfg)` wired into all 8 `mcp.Tool{}` constructions

---

## Item 2 — `ToolAnnotations.OpenWorldHint`: corrected from `false` → `true`

All Trino tools communicate with an external Trino cluster — `OpenWorldHint: false` was semantically incorrect. Changed to `true` for all 8 tools with a comment in `annotations.go` explaining why.

---

## Item 3 — `Tool.OutputSchema`: already inferred by the SDK

No code change needed. The go-sdk's `AddTool` generic function automatically infers and sets `OutputSchema` from the typed handler's output type parameter at registration time ([`server.go:305`](https://github.com/modelcontextprotocol/go-sdk/blob/main/mcp/server.go#L305)). All tools already use typed handlers returning concrete output structs (`*QueryOutput`, `*ExplainOutput`, `*ListCatalogsOutput`, etc.), so `OutputSchema` is already populated and served to clients without additional code.

---

## Files changed

| File | Change |
|---|---|
| `pkg/tools/titles.go` | **new** — default titles, `DefaultTitle()`, `getTitle()` |
| `pkg/tools/titles_test.go` | **new** — full test coverage for title resolution |
| `pkg/tools/options.go` | `title *string` in `toolConfig`; `WithTitle`, `WithTitles` |
| `pkg/tools/toolkit.go` | `titles` map field + init in `newBaseToolkit` |
| `pkg/tools/query.go` | `Title:` in `mcp.Tool{}` |
| `pkg/tools/execute.go` | `Title:` in `mcp.Tool{}` |
| `pkg/tools/explain.go` | `Title:` in `mcp.Tool{}` |
| `pkg/tools/schema.go` | `Title:` in all 4 `mcp.Tool{}` registrations |
| `pkg/tools/connections.go` | `Title:` in `mcp.Tool{}`; `//nolint:dupl` to suppress structural duplicate warning |
| `pkg/tools/annotations.go` | `OpenWorldHint: boolPtr(true)` for all 8 tools |
| `pkg/tools/annotations_test.go` | Updated assertions + new `TestDefaultAnnotations_AllToolsOpenWorld` |
| `pkg/tools/options_test.go` | Tests for `WithTitle`, `WithTitles`, `WithTitles` merge |

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] `gocyclo -over 15 .` — no results
- [x] `make lint` — no new issues introduced (13 pre-existing `gosec`/`staticcheck` issues are unrelated to this change)
- [x] Branch rebased onto current `origin/main` (includes `go-sdk` bump in `deps: bump github.com/modelcontextprotocol/go-sdk (#40)`)