### PR TITLE
feat: validate format param, surface in tool prose, add opt-in JSON unwrap

### DIFF
--- a/pkg/tools/descriptions.go
+++ b/pkg/tools/descriptions.go
@@ -9,12 +9,20 @@ var defaultDescriptions = map[ToolName]string{
 		"excessive data transfer — use the limit parameter to control result size. " +
 		"For large tables, always include WHERE clauses to filter results. " +
 		"Consider using trino_explain first for expensive queries. " +
+		"Results are returned as JSON by default. Pass format=csv for CSV output " +
+		"(more token-efficient for large result sets) or format=markdown for a pipe-table. " +
+		"Set unwrap_json=true to automatically parse single-row, single-VARCHAR-column " +
+		"results containing JSON (common with table functions like raw_query). " +
 		"For write operations (INSERT, CREATE, etc.), use trino_execute instead.",
 
 	ToolExecute: "Execute a SQL statement against Trino, including write operations " +
 		"(INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, etc.). Returns affected row " +
 		"counts or query results. Use trino_query for read-only SELECT queries. " +
-		"This tool should be used when you need to modify data or schema.",
+		"This tool should be used when you need to modify data or schema. " +
+		"Results are returned as JSON by default. Pass format=csv for CSV output " +
+		"(more token-efficient for large result sets) or format=markdown for a pipe-table. " +
+		"Set unwrap_json=true to automatically parse single-row, single-VARCHAR-column " +
+		"results containing JSON (common with table functions like raw_query).",
 
 	ToolExplain: "Get the execution plan for a SQL query to understand performance characteristics " +
 		"before running expensive queries. Use this when querying large tables (millions of " +

--- a/pkg/tools/descriptions.go
+++ b/pkg/tools/descriptions.go
@@ -22,8 +22,9 @@ var defaultDescriptions = map[ToolName]string{
 		"This tool should be used when you need to modify data or schema. " +
 		"Results are returned as JSON by default. Pass format=csv for CSV output " +
 		"(more token-efficient for large result sets) or format=markdown for a pipe-table. " +
-		"Set unwrap_json=true to automatically parse single-row, single-VARCHAR-column " +
-		"results containing JSON (common with table functions like raw_query).",
+		"Set unwrap_json=true to automatically parse single-row, single-string-column " +
+		"results containing a JSON object or array — the column type changes to JSON " +
+		"and the value becomes the parsed object (common with table functions like raw_query).",
 
 	ToolExplain: "Get the execution plan for a SQL query to understand performance characteristics " +
 		"before running expensive queries. Use this when querying large tables (millions of " +

--- a/pkg/tools/descriptions.go
+++ b/pkg/tools/descriptions.go
@@ -11,8 +11,9 @@ var defaultDescriptions = map[ToolName]string{
 		"Consider using trino_explain first for expensive queries. " +
 		"Results are returned as JSON by default. Pass format=csv for CSV output " +
 		"(more token-efficient for large result sets) or format=markdown for a pipe-table. " +
-		"Set unwrap_json=true to automatically parse single-row, single-VARCHAR-column " +
-		"results containing JSON (common with table functions like raw_query). " +
+		"Set unwrap_json=true to automatically parse single-row, single-string-column " +
+		"results containing a JSON object or array — the column type changes to JSON " +
+		"and the value becomes the parsed object (common with table functions like raw_query). " +
 		"For write operations (INSERT, CREATE, etc.), use trino_execute instead.",
 
 	ToolExecute: "Execute a SQL statement against Trino, including write operations " +

--- a/pkg/tools/execute.go
+++ b/pkg/tools/execute.go
@@ -27,8 +27,7 @@ type ExecuteInput struct {
 	// UnwrapJSON controls automatic JSON unwrapping for single-row, single-VARCHAR-column results.
 	// When true and the result is exactly one row with one VARCHAR column containing valid JSON,
 	// the parsed JSON is included in the response as unwrapped_result.
-	//nolint:lll // jsonschema_description must be a single tag value
-	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-VARCHAR-column containing valid JSON, include parsed JSON as unwrapped_result"`
+	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-VARCHAR-column containing valid JSON, include parsed JSON as unwrapped_result"` //nolint:lll // jsonschema_description must be a single tag value
 
 	// Connection is the named connection to use. Empty uses the default connection.
 	// Use trino_list_connections to see available connections.
@@ -127,15 +126,6 @@ func (t *Toolkit) handleExecute(ctx context.Context, _ *mcp.CallToolRequest, inp
 	notifyProgress(ctx, notifier, 1, 3,
 		fmt.Sprintf("Statement returned %d rows, formatting...", result.Stats.RowCount))
 
-	// Format output
-	output, err := formatOutput(result, input.Format)
-	if err != nil {
-		return ErrorResult(err.Error()), nil, nil
-	}
-
-	// Send progress notification: complete
-	notifyProgress(ctx, notifier, 2, 3, "Execution complete")
-
 	// Build structured output (reuse QueryOutput — same result shape)
 	queryOutput := buildQueryOutput(result)
 
@@ -145,6 +135,15 @@ func (t *Toolkit) handleExecute(ctx context.Context, _ *mcp.CallToolRequest, inp
 			queryOutput.UnwrappedResult = parsed
 		}
 	}
+
+	// Render text content
+	output, err := renderTextContent(result, &queryOutput, input.Format)
+	if err != nil {
+		return ErrorResult(err.Error()), nil, nil
+	}
+
+	// Send progress notification: complete
+	notifyProgress(ctx, notifier, 2, 3, "Execution complete")
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/pkg/tools/execute.go
+++ b/pkg/tools/execute.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -24,6 +23,12 @@ type ExecuteInput struct {
 
 	// Format is the output format: json (default), csv, or markdown.
 	Format string `json:"format,omitempty" jsonschema_description:"Output format: json, csv, or markdown (default: json)"`
+
+	// UnwrapJSON controls automatic JSON unwrapping for single-row, single-VARCHAR-column results.
+	// When true and the result is exactly one row with one VARCHAR column containing valid JSON,
+	// the parsed JSON is included in the response as unwrapped_result.
+	//nolint:lll // jsonschema_description must be a single tag value
+	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-VARCHAR-column containing valid JSON, include parsed JSON as unwrapped_result"`
 
 	// Connection is the named connection to use. Empty uses the default connection.
 	// Use trino_list_connections to see available connections.
@@ -66,6 +71,11 @@ func (t *Toolkit) handleExecute(ctx context.Context, _ *mcp.CallToolRequest, inp
 	// Validate SQL is provided
 	if input.SQL == "" {
 		return ErrorResult("sql parameter is required"), nil, nil
+	}
+
+	// Validate format
+	if err := validateFormat(input.Format); err != nil {
+		return ErrorResult(err.Error()), nil, nil
 	}
 
 	// Apply query interceptors (no read-only enforcement — that's the point of trino_execute)
@@ -118,23 +128,9 @@ func (t *Toolkit) handleExecute(ctx context.Context, _ *mcp.CallToolRequest, inp
 		fmt.Sprintf("Statement returned %d rows, formatting...", result.Stats.RowCount))
 
 	// Format output
-	format := input.Format
-	if format == "" {
-		format = "json"
-	}
-
-	var output string
-	switch format {
-	case "csv":
-		output = formatCSV(result)
-	case "markdown":
-		output = formatMarkdown(result)
-	default:
-		data, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return ErrorResult(fmt.Sprintf("Failed to marshal result: %v", err)), nil, nil
-		}
-		output = string(data)
+	output, err := formatOutput(result, input.Format)
+	if err != nil {
+		return ErrorResult(err.Error()), nil, nil
 	}
 
 	// Send progress notification: complete
@@ -142,6 +138,13 @@ func (t *Toolkit) handleExecute(ctx context.Context, _ *mcp.CallToolRequest, inp
 
 	// Build structured output (reuse QueryOutput — same result shape)
 	queryOutput := buildQueryOutput(result)
+
+	// Attempt JSON unwrap if requested
+	if input.UnwrapJSON {
+		if parsed, ok := tryUnwrapJSON(result); ok {
+			queryOutput.UnwrappedResult = parsed
+		}
+	}
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/pkg/tools/execute.go
+++ b/pkg/tools/execute.go
@@ -24,10 +24,10 @@ type ExecuteInput struct {
 	// Format is the output format: json (default), csv, or markdown.
 	Format string `json:"format,omitempty" jsonschema_description:"Output format: json, csv, or markdown (default: json)"`
 
-	// UnwrapJSON controls automatic JSON unwrapping for single-row, single-VARCHAR-column results.
-	// When true and the result is exactly one row with one VARCHAR column containing valid JSON,
-	// the parsed JSON is included in the response as unwrapped_result.
-	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-VARCHAR-column containing valid JSON, include parsed JSON as unwrapped_result"` //nolint:lll // jsonschema_description must be a single tag value
+	// UnwrapJSON controls automatic JSON unwrapping for single-row, single-string-column results.
+	// When true and the result matches, the column type is changed to "JSON" and the row value
+	// is replaced with the parsed object. The envelope shape is unchanged.
+	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-string-column containing a JSON object or array, parse the value inline and set column type to JSON"` //nolint:lll // jsonschema_description must be a single tag value
 
 	// Connection is the named connection to use. Empty uses the default connection.
 	// Use trino_list_connections to see available connections.
@@ -129,15 +129,14 @@ func (t *Toolkit) handleExecute(ctx context.Context, _ *mcp.CallToolRequest, inp
 	// Build structured output (reuse QueryOutput — same result shape)
 	queryOutput := buildQueryOutput(result)
 
-	// Attempt JSON unwrap if requested
+	// Attempt JSON unwrap if requested — mutates queryOutput in place,
+	// changing columns[0].type to "JSON" and replacing the row value.
 	if input.UnwrapJSON {
-		if parsed, ok := tryUnwrapJSON(result); ok {
-			queryOutput.UnwrappedResult = parsed
-		}
+		unwrapJSONColumn(&queryOutput)
 	}
 
-	// Render text content
-	output, err := renderTextContent(result, &queryOutput, input.Format)
+	// Format output
+	output, err := formatOutput(&queryOutput, input.Format)
 	if err != nil {
 		return ErrorResult(err.Error()), nil, nil
 	}

--- a/pkg/tools/explain.go
+++ b/pkg/tools/explain.go
@@ -59,6 +59,11 @@ func (t *Toolkit) handleExplain(ctx context.Context, _ *mcp.CallToolRequest, inp
 		return ErrorResult("sql parameter is required"), nil, nil
 	}
 
+	// Validate explain type
+	if err := validateExplainType(input.Type); err != nil {
+		return ErrorResult(err.Error()), nil, nil
+	}
+
 	// Apply query interceptors
 	sql, err := t.InterceptSQL(ctx, input.SQL, ToolExplain)
 	if err != nil {

--- a/pkg/tools/explain_test.go
+++ b/pkg/tools/explain_test.go
@@ -80,14 +80,14 @@ func TestExplainInput_TypeMapping(t *testing.T) {
 			expectedType: client.ExplainLogical,
 		},
 		{
-			name:         "unknown defaults to logical",
+			name:         "unknown defaults to logical in switch",
 			inputType:    "unknown",
 			expectedType: client.ExplainLogical,
 		},
 		{
-			name:         "LOGICAL uppercase defaults to logical",
+			name:         "LOGICAL uppercase defaults to logical in switch",
 			inputType:    "LOGICAL",
-			expectedType: client.ExplainLogical, // Case sensitive, defaults
+			expectedType: client.ExplainLogical,
 		},
 	}
 

--- a/pkg/tools/explain_test.go
+++ b/pkg/tools/explain_test.go
@@ -79,16 +79,9 @@ func TestExplainInput_TypeMapping(t *testing.T) {
 			inputType:    "",
 			expectedType: client.ExplainLogical,
 		},
-		{
-			name:         "unknown defaults to logical in switch",
-			inputType:    "unknown",
-			expectedType: client.ExplainLogical,
-		},
-		{
-			name:         "LOGICAL uppercase defaults to logical in switch",
-			inputType:    "LOGICAL",
-			expectedType: client.ExplainLogical,
-		},
+		// "unknown" and "LOGICAL" are now rejected by validateExplainType
+		// before reaching the switch. Invalid types are tested in
+		// TestHandleExplain_InvalidType in handlers_test.go.
 	}
 
 	for _, tt := range tests {

--- a/pkg/tools/format.go
+++ b/pkg/tools/format.go
@@ -8,8 +8,15 @@ import (
 	"github.com/txn2/mcp-trino/pkg/client"
 )
 
+// Output format identifiers.
+const (
+	outputFormatJSON     = "json"
+	outputFormatCSV      = "csv"
+	outputFormatMarkdown = "markdown"
+)
+
 // validFormats lists the accepted output format values.
-var validFormats = []string{"json", "csv", "markdown"}
+var validFormats = []string{outputFormatJSON, outputFormatCSV, outputFormatMarkdown}
 
 // validateFormat checks that the given format is valid.
 // An empty string is always valid (defaults to "json").
@@ -26,40 +33,88 @@ func validateFormat(format string) error {
 	return fmt.Errorf("invalid format %q: must be one of %s", format, strings.Join(validFormats, ", "))
 }
 
+// validExplainTypes lists the accepted explain type values.
+var validExplainTypes = []string{"logical", "distributed", "io", "validate"}
+
+// validateExplainType checks that the given explain type is valid.
+// An empty string is always valid (defaults to "logical").
+// Returns an error naming the accepted values if the type is not recognized.
+func validateExplainType(explainType string) error {
+	if explainType == "" {
+		return nil
+	}
+	for _, v := range validExplainTypes {
+		if explainType == v {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid explain type %q: must be one of %s",
+		explainType, strings.Join(validExplainTypes, ", "))
+}
+
 // formatOutput renders a QueryResult in the requested format.
 // The format must already be validated via validateFormat.
 func formatOutput(result *client.QueryResult, format string) (string, error) {
 	if format == "" {
-		format = "json"
+		format = outputFormatJSON
 	}
 
 	switch format {
-	case "csv":
+	case outputFormatCSV:
 		return formatCSV(result), nil
-	case "markdown":
+	case outputFormatMarkdown:
 		return formatMarkdown(result), nil
-	default:
+	case outputFormatJSON:
 		data, err := json.MarshalIndent(result, "", "  ")
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal result: %w", err)
 		}
 		return string(data), nil
+	default:
+		return "", fmt.Errorf("unsupported format %q", format)
 	}
 }
 
-// tryUnwrapJSON attempts to unwrap a single-row, single-VARCHAR-column result
-// containing a JSON string. Returns the parsed JSON and true if unwrapping
-// succeeded, or nil and false if the result doesn't match the expected shape
-// or the value isn't valid JSON.
+// renderTextContent produces the text output for a tool response.
+// If unwrap succeeded and format is JSON, it renders the full QueryOutput
+// (including unwrapped_result) so the LLM sees clean JSON in its context.
+// Otherwise it renders the raw query result in the requested format.
+func renderTextContent(result *client.QueryResult, queryOutput *QueryOutput, format string) (string, error) {
+	if queryOutput.UnwrappedResult != nil && (format == "" || format == outputFormatJSON) {
+		data, err := json.MarshalIndent(queryOutput, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal result: %w", err)
+		}
+		return string(data), nil
+	}
+	return formatOutput(result, format)
+}
+
+// isStringColumnType returns true if the Trino type name is a string-like type
+// that could contain JSON: VARCHAR, VARCHAR(N), CHAR, CHAR(N), or JSON.
+func isStringColumnType(typeName string) bool {
+	lower := strings.ToLower(typeName)
+	if lower == "varchar" || lower == "char" || lower == "json" {
+		return true
+	}
+	if strings.HasPrefix(lower, "varchar(") || strings.HasPrefix(lower, "char(") {
+		return true
+	}
+	return false
+}
+
+// tryUnwrapJSON attempts to unwrap a single-row, single-string-column result
+// containing a JSON object or array. Returns the parsed JSON and true if
+// unwrapping succeeded, or nil and false if the result doesn't match the
+// expected shape, the value isn't valid JSON, or the value is a JSON scalar.
 func tryUnwrapJSON(result *client.QueryResult) (any, bool) {
 	// Must be exactly one column
 	if len(result.Columns) != 1 {
 		return nil, false
 	}
 
-	// Column must be VARCHAR type
-	if !strings.EqualFold(result.Columns[0].Type, "VARCHAR") &&
-		!strings.HasPrefix(strings.ToLower(result.Columns[0].Type), "varchar(") {
+	// Column must be a string-like type (VARCHAR, CHAR, JSON)
+	if !isStringColumnType(result.Columns[0].Type) {
 		return nil, false
 	}
 
@@ -85,5 +140,13 @@ func tryUnwrapJSON(result *client.QueryResult) (any, bool) {
 		return nil, false
 	}
 
-	return parsed, true
+	// Only unwrap objects and arrays — scalar JSON values (strings, numbers,
+	// booleans, null) are not meaningful to unwrap and would be confusing
+	// or silently change types.
+	switch parsed.(type) {
+	case map[string]any, []any:
+		return parsed, true
+	default:
+		return nil, false
+	}
 }

--- a/pkg/tools/format.go
+++ b/pkg/tools/format.go
@@ -177,6 +177,32 @@ func stringifyValue(v any) string {
 	}
 }
 
+// escapeCSV escapes a value for CSV output.
+func escapeCSV(s string) string {
+	needsQuoting := false
+	for _, c := range s {
+		if c == ',' || c == '"' || c == '\n' || c == '\r' {
+			needsQuoting = true
+			break
+		}
+	}
+	if !needsQuoting {
+		return s
+	}
+
+	// Escape quotes and wrap in quotes
+	result := "\""
+	for _, c := range s {
+		if c == '"' {
+			result += "\"\""
+		} else {
+			result += string(c)
+		}
+	}
+	result += "\""
+	return result
+}
+
 // isStringColumnType returns true if the Trino type name is a string-like type
 // that could contain JSON: VARCHAR, VARCHAR(N), CHAR, CHAR(N), or JSON.
 func isStringColumnType(typeName string) bool {
@@ -227,8 +253,15 @@ func unwrapJSONColumn(qo *QueryOutput) {
 	// or silently change types.
 	switch parsed.(type) {
 	case map[string]any, []any:
+		// Shallow-copy the row map before mutation so we don't modify the
+		// original client.QueryResult.Rows (which shares the slice).
+		row := make(map[string]any, len(qo.Rows[0]))
+		for k, v := range qo.Rows[0] {
+			row[k] = v
+		}
+		row[colName] = parsed
+		qo.Rows[0] = row
 		qo.Columns[0].Type = columnTypeJSON
-		qo.Rows[0][colName] = parsed
 	default:
 		// Fall through — leave QueryOutput unchanged.
 	}

--- a/pkg/tools/format.go
+++ b/pkg/tools/format.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/txn2/mcp-trino/pkg/client"
 )
 
 // Output format identifiers.
@@ -14,6 +12,10 @@ const (
 	outputFormatCSV      = "csv"
 	outputFormatMarkdown = "markdown"
 )
+
+// columnTypeJSON is the column type set when unwrapJSONColumn successfully
+// parses a string column value into a JSON object or array.
+const columnTypeJSON = "JSON"
 
 // validFormats lists the accepted output format values.
 var validFormats = []string{outputFormatJSON, outputFormatCSV, outputFormatMarkdown}
@@ -34,6 +36,7 @@ func validateFormat(format string) error {
 }
 
 // validExplainTypes lists the accepted explain type values.
+// Must be kept in sync with the switch in handleExplain.
 var validExplainTypes = []string{"logical", "distributed", "io", "validate"}
 
 // validateExplainType checks that the given explain type is valid.
@@ -52,20 +55,19 @@ func validateExplainType(explainType string) error {
 		explainType, strings.Join(validExplainTypes, ", "))
 }
 
-// formatOutput renders a QueryResult in the requested format.
-// The format must already be validated via validateFormat.
-func formatOutput(result *client.QueryResult, format string) (string, error) {
+// formatOutput renders a QueryOutput in the requested format.
+func formatOutput(qo *QueryOutput, format string) (string, error) {
 	if format == "" {
 		format = outputFormatJSON
 	}
 
 	switch format {
 	case outputFormatCSV:
-		return formatCSV(result), nil
+		return formatCSV(qo), nil
 	case outputFormatMarkdown:
-		return formatMarkdown(result), nil
+		return formatMarkdown(qo), nil
 	case outputFormatJSON:
-		data, err := json.MarshalIndent(result, "", "  ")
+		data, err := json.MarshalIndent(qo, "", "  ")
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal result: %w", err)
 		}
@@ -75,19 +77,104 @@ func formatOutput(result *client.QueryResult, format string) (string, error) {
 	}
 }
 
-// renderTextContent produces the text output for a tool response.
-// If unwrap succeeded and format is JSON, it renders the full QueryOutput
-// (including unwrapped_result) so the LLM sees clean JSON in its context.
-// Otherwise it renders the raw query result in the requested format.
-func renderTextContent(result *client.QueryResult, queryOutput *QueryOutput, format string) (string, error) {
-	if queryOutput.UnwrappedResult != nil && (format == "" || format == outputFormatJSON) {
-		data, err := json.MarshalIndent(queryOutput, "", "  ")
-		if err != nil {
-			return "", fmt.Errorf("failed to marshal result: %w", err)
-		}
-		return string(data), nil
+// formatCSV formats query output as CSV.
+func formatCSV(qo *QueryOutput) string {
+	if len(qo.Columns) == 0 {
+		return ""
 	}
-	return formatOutput(result, format)
+
+	var output string
+
+	// Header row
+	for i, col := range qo.Columns {
+		if i > 0 {
+			output += ","
+		}
+		output += escapeCSV(col.Name)
+	}
+	output += "\n"
+
+	// Data rows
+	for _, row := range qo.Rows {
+		for i, col := range qo.Columns {
+			if i > 0 {
+				output += ","
+			}
+			if val, ok := row[col.Name]; ok {
+				output += escapeCSV(stringifyValue(val))
+			}
+		}
+		output += "\n"
+	}
+
+	// Stats footer
+	output += fmt.Sprintf("\n# %d rows returned", qo.Stats.RowCount)
+	if qo.Stats.Truncated {
+		output += fmt.Sprintf(" (truncated at limit %d)", qo.Stats.LimitApplied)
+	}
+	output += fmt.Sprintf(", executed in %dms", qo.Stats.DurationMs)
+
+	return output
+}
+
+// formatMarkdown formats query output as a Markdown table.
+func formatMarkdown(qo *QueryOutput) string {
+	if len(qo.Columns) == 0 {
+		return "No results"
+	}
+
+	var output string
+
+	// Header row
+	output += "|"
+	for _, col := range qo.Columns {
+		output += " " + col.Name + " |"
+	}
+	output += "\n|"
+
+	// Separator row
+	for range qo.Columns {
+		output += " --- |"
+	}
+	output += "\n"
+
+	// Data rows
+	for _, row := range qo.Rows {
+		output += "|"
+		for _, col := range qo.Columns {
+			val := ""
+			if v, ok := row[col.Name]; ok && v != nil {
+				val = stringifyValue(v)
+			}
+			output += " " + val + " |"
+		}
+		output += "\n"
+	}
+
+	// Stats footer
+	output += fmt.Sprintf("\n*%d rows returned", qo.Stats.RowCount)
+	if qo.Stats.Truncated {
+		output += fmt.Sprintf(" (truncated at limit %d)", qo.Stats.LimitApplied)
+	}
+	output += fmt.Sprintf(", executed in %dms*", qo.Stats.DurationMs)
+
+	return output
+}
+
+// stringifyValue converts a value to its string representation.
+// For maps and slices (e.g. unwrapped JSON), it produces compact JSON.
+// For all other types, it uses fmt.Sprintf.
+func stringifyValue(v any) string {
+	switch v.(type) {
+	case map[string]any, []any:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(data)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }
 
 // isStringColumnType returns true if the Trino type name is a string-like type
@@ -103,41 +190,36 @@ func isStringColumnType(typeName string) bool {
 	return false
 }
 
-// tryUnwrapJSON attempts to unwrap a single-row, single-string-column result
-// containing a JSON object or array. Returns the parsed JSON and true if
-// unwrapping succeeded, or nil and false if the result doesn't match the
-// expected shape, the value isn't valid JSON, or the value is a JSON scalar.
-func tryUnwrapJSON(result *client.QueryResult) (any, bool) {
-	// Must be exactly one column
-	if len(result.Columns) != 1 {
-		return nil, false
-	}
-
-	// Column must be a string-like type (VARCHAR, CHAR, JSON)
-	if !isStringColumnType(result.Columns[0].Type) {
-		return nil, false
+// unwrapJSONColumn attempts to unwrap a single-row, single-string-column
+// QueryOutput whose value is a JSON object or array. On success it mutates
+// the QueryOutput in place: the column type is changed to "JSON" and the
+// row value is replaced with the parsed object. On failure the QueryOutput
+// is left unchanged.
+func unwrapJSONColumn(qo *QueryOutput) {
+	// Must be exactly one column with a string-like type
+	if len(qo.Columns) != 1 || !isStringColumnType(qo.Columns[0].Type) {
+		return
 	}
 
 	// Must be exactly one row
-	if len(result.Rows) != 1 {
-		return nil, false
+	if len(qo.Rows) != 1 {
+		return
 	}
 
-	// Get the column value
-	val, ok := result.Rows[0][result.Columns[0].Name]
+	colName := qo.Columns[0].Name
+	val, ok := qo.Rows[0][colName]
 	if !ok {
-		return nil, false
+		return
 	}
 
 	str, ok := val.(string)
 	if !ok {
-		return nil, false
+		return
 	}
 
-	// Try to parse as JSON
 	var parsed any
 	if err := json.Unmarshal([]byte(str), &parsed); err != nil {
-		return nil, false
+		return
 	}
 
 	// Only unwrap objects and arrays — scalar JSON values (strings, numbers,
@@ -145,8 +227,9 @@ func tryUnwrapJSON(result *client.QueryResult) (any, bool) {
 	// or silently change types.
 	switch parsed.(type) {
 	case map[string]any, []any:
-		return parsed, true
+		qo.Columns[0].Type = columnTypeJSON
+		qo.Rows[0][colName] = parsed
 	default:
-		return nil, false
+		// Fall through — leave QueryOutput unchanged.
 	}
 }

--- a/pkg/tools/format.go
+++ b/pkg/tools/format.go
@@ -1,0 +1,89 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/txn2/mcp-trino/pkg/client"
+)
+
+// validFormats lists the accepted output format values.
+var validFormats = []string{"json", "csv", "markdown"}
+
+// validateFormat checks that the given format is valid.
+// An empty string is always valid (defaults to "json").
+// Returns an error naming the accepted values if the format is not recognized.
+func validateFormat(format string) error {
+	if format == "" {
+		return nil
+	}
+	for _, v := range validFormats {
+		if format == v {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid format %q: must be one of %s", format, strings.Join(validFormats, ", "))
+}
+
+// formatOutput renders a QueryResult in the requested format.
+// The format must already be validated via validateFormat.
+func formatOutput(result *client.QueryResult, format string) (string, error) {
+	if format == "" {
+		format = "json"
+	}
+
+	switch format {
+	case "csv":
+		return formatCSV(result), nil
+	case "markdown":
+		return formatMarkdown(result), nil
+	default:
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal result: %w", err)
+		}
+		return string(data), nil
+	}
+}
+
+// tryUnwrapJSON attempts to unwrap a single-row, single-VARCHAR-column result
+// containing a JSON string. Returns the parsed JSON and true if unwrapping
+// succeeded, or nil and false if the result doesn't match the expected shape
+// or the value isn't valid JSON.
+func tryUnwrapJSON(result *client.QueryResult) (any, bool) {
+	// Must be exactly one column
+	if len(result.Columns) != 1 {
+		return nil, false
+	}
+
+	// Column must be VARCHAR type
+	if !strings.EqualFold(result.Columns[0].Type, "VARCHAR") &&
+		!strings.HasPrefix(strings.ToLower(result.Columns[0].Type), "varchar(") {
+		return nil, false
+	}
+
+	// Must be exactly one row
+	if len(result.Rows) != 1 {
+		return nil, false
+	}
+
+	// Get the column value
+	val, ok := result.Rows[0][result.Columns[0].Name]
+	if !ok {
+		return nil, false
+	}
+
+	str, ok := val.(string)
+	if !ok {
+		return nil, false
+	}
+
+	// Try to parse as JSON
+	var parsed any
+	if err := json.Unmarshal([]byte(str), &parsed); err != nil {
+		return nil, false
+	}
+
+	return parsed, true
+}

--- a/pkg/tools/format_test.go
+++ b/pkg/tools/format_test.go
@@ -1,0 +1,251 @@
+package tools
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/txn2/mcp-trino/pkg/client"
+)
+
+func TestValidateFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "empty string is valid", format: "", wantErr: false},
+		{name: "json is valid", format: "json", wantErr: false},
+		{name: "csv is valid", format: "csv", wantErr: false},
+		{name: "markdown is valid", format: "markdown", wantErr: false},
+		{name: "tsv is invalid", format: "tsv", wantErr: true, errMsg: `invalid format "tsv"`},
+		{name: "table is invalid", format: "table", wantErr: true, errMsg: `invalid format "table"`},
+		{name: "JSON uppercase is invalid", format: "JSON", wantErr: true, errMsg: `invalid format "JSON"`},
+		{name: "Csv mixed case is invalid", format: "Csv", wantErr: true, errMsg: `invalid format "Csv"`},
+		{name: "ndjson is invalid", format: "ndjson", wantErr: true, errMsg: `invalid format "ndjson"`},
+		{name: "error names valid values", format: "bad", wantErr: true, errMsg: "json, csv, markdown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFormat(tt.format)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for format %q, got nil", tt.format)
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for format %q: %v", tt.format, err)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatOutput(t *testing.T) {
+	result := &client.QueryResult{
+		Columns: []client.ColumnInfo{
+			{Name: "id", Type: "INTEGER"},
+			{Name: "name", Type: "VARCHAR"},
+		},
+		Rows: []map[string]any{
+			{"id": 1, "name": "Alice"},
+		},
+		Stats: client.QueryStats{
+			RowCount:   1,
+			DurationMs: 50,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		format   string
+		contains string
+	}{
+		{name: "empty defaults to json", format: "", contains: "Alice"},
+		{name: "json format", format: "json", contains: "Alice"},
+		{name: "csv format", format: "csv", contains: "id,name"},
+		{name: "markdown format", format: "markdown", contains: "| id | name |"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := formatOutput(result, tt.format)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(output, tt.contains) {
+				t.Errorf("expected output to contain %q, got:\n%s", tt.contains, output)
+			}
+		})
+	}
+}
+
+func TestTryUnwrapJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   *client.QueryResult
+		wantOK   bool
+		wantJSON string // JSON representation of expected parsed value, empty if wantOK is false
+	}{
+		{
+			name: "single VARCHAR column with valid JSON object",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"result": `{"took":2,"aggregations":{"count":42}}`}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK:   true,
+			wantJSON: `{"took":2,"aggregations":{"count":42}}`,
+		},
+		{
+			name: "single VARCHAR column with valid JSON array",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "data", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"data": `[1,2,3]`}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK:   true,
+			wantJSON: `[1,2,3]`,
+		},
+		{
+			name: "VARCHAR with length constraint",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "varchar(65535)"}},
+				Rows:    []map[string]any{{"result": `{"key":"value"}`}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK:   true,
+			wantJSON: `{"key":"value"}`,
+		},
+		{
+			name: "multiple columns - no unwrap",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{
+					{Name: "id", Type: "INTEGER"},
+					{Name: "name", Type: "VARCHAR"},
+				},
+				Rows:  []map[string]any{{"id": 1, "name": "Alice"}},
+				Stats: client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
+			name: "single column non-VARCHAR type - no unwrap",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "count", Type: "BIGINT"}},
+				Rows:    []map[string]any{{"count": 42}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
+			name: "multiple rows - no unwrap",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows: []map[string]any{
+					{"result": `{"a":1}`},
+					{"result": `{"b":2}`},
+				},
+				Stats: client.QueryStats{RowCount: 2},
+			},
+			wantOK: false,
+		},
+		{
+			name: "zero rows - no unwrap",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{},
+				Stats:   client.QueryStats{RowCount: 0},
+			},
+			wantOK: false,
+		},
+		{
+			name: "single VARCHAR column with non-JSON string",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"result": "hello world"}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
+			name: "single VARCHAR column with empty string",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"result": ""}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
+			name: "single VARCHAR column with nil value",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"result": nil}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
+			name: "single VARCHAR column with non-string value",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"result": 42}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
+			name: "no columns - no unwrap",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{},
+				Rows:    []map[string]any{},
+				Stats:   client.QueryStats{},
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, ok := tryUnwrapJSON(tt.result)
+			if ok != tt.wantOK {
+				t.Errorf("tryUnwrapJSON() ok = %v, want %v", ok, tt.wantOK)
+				return
+			}
+			if tt.wantOK && tt.wantJSON != "" {
+				got, err := json.Marshal(parsed)
+				if err != nil {
+					t.Fatalf("failed to marshal parsed result: %v", err)
+				}
+				// Compare as JSON to avoid whitespace differences
+				var expected, actual any
+				if err := json.Unmarshal([]byte(tt.wantJSON), &expected); err != nil {
+					t.Fatalf("failed to unmarshal expected JSON: %v", err)
+				}
+				if err := json.Unmarshal(got, &actual); err != nil {
+					t.Fatalf("failed to unmarshal actual JSON: %v", err)
+				}
+				expectedBytes, errE := json.Marshal(expected)
+				if errE != nil {
+					t.Fatalf("failed to marshal expected: %v", errE)
+				}
+				actualBytes, errA := json.Marshal(actual)
+				if errA != nil {
+					t.Fatalf("failed to marshal actual: %v", errA)
+				}
+				if !bytes.Equal(expectedBytes, actualBytes) {
+					t.Errorf("parsed JSON = %s, want %s", string(actualBytes), string(expectedBytes))
+				}
+			}
+			if !tt.wantOK && parsed != nil {
+				t.Errorf("expected nil parsed result when ok is false, got %v", parsed)
+			}
+		})
+	}
+}

--- a/pkg/tools/format_test.go
+++ b/pkg/tools/format_test.go
@@ -1,7 +1,6 @@
 package tools
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -46,6 +45,41 @@ func TestValidateFormat(t *testing.T) {
 	}
 }
 
+func TestValidateExplainType(t *testing.T) {
+	tests := []struct {
+		name    string
+		typ     string
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "empty string is valid", typ: "", wantErr: false},
+		{name: "logical is valid", typ: "logical", wantErr: false},
+		{name: "distributed is valid", typ: "distributed", wantErr: false},
+		{name: "io is valid", typ: "io", wantErr: false},
+		{name: "validate is valid", typ: "validate", wantErr: false},
+		{name: "LOGICAL uppercase is invalid", typ: "LOGICAL", wantErr: true, errMsg: `invalid explain type "LOGICAL"`},
+		{name: "unknown is invalid", typ: "unknown", wantErr: true, errMsg: "must be one of"},
+		{name: "error names valid values", typ: "bad", wantErr: true, errMsg: "logical, distributed, io, validate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExplainType(tt.typ)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for type %q, got nil", tt.typ)
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for type %q: %v", tt.typ, err)
+				}
+			}
+		})
+	}
+}
+
 func TestFormatOutput(t *testing.T) {
 	result := &client.QueryResult{
 		Columns: []client.ColumnInfo{
@@ -83,6 +117,46 @@ func TestFormatOutput(t *testing.T) {
 			}
 		})
 	}
+
+	// Verify unsupported format returns error
+	t.Run("unsupported format returns error", func(t *testing.T) {
+		_, err := formatOutput(result, "tsv")
+		if err == nil {
+			t.Error("expected error for unsupported format")
+		}
+	})
+}
+
+func TestIsStringColumnType(t *testing.T) {
+	tests := []struct {
+		typeName string
+		want     bool
+	}{
+		{"VARCHAR", true},
+		{"varchar", true},
+		{"varchar(65535)", true},
+		{"VARCHAR(255)", true},
+		{"CHAR", true},
+		{"char", true},
+		{"char(10)", true},
+		{"CHAR(1)", true},
+		{"JSON", true},
+		{"json", true},
+		{"BIGINT", false},
+		{"INTEGER", false},
+		{"BOOLEAN", false},
+		{"TIMESTAMP", false},
+		{"VARBINARY", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.typeName, func(t *testing.T) {
+			got := isStringColumnType(tt.typeName)
+			if got != tt.want {
+				t.Errorf("isStringColumnType(%q) = %v, want %v", tt.typeName, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestTryUnwrapJSON(t *testing.T) {
@@ -90,7 +164,7 @@ func TestTryUnwrapJSON(t *testing.T) {
 		name     string
 		result   *client.QueryResult
 		wantOK   bool
-		wantJSON string // JSON representation of expected parsed value, empty if wantOK is false
+		wantJSON string
 	}{
 		{
 			name: "single VARCHAR column with valid JSON object",
@@ -100,7 +174,7 @@ func TestTryUnwrapJSON(t *testing.T) {
 				Stats:   client.QueryStats{RowCount: 1},
 			},
 			wantOK:   true,
-			wantJSON: `{"took":2,"aggregations":{"count":42}}`,
+			wantJSON: `{"aggregations":{"count":42},"took":2}`,
 		},
 		{
 			name: "single VARCHAR column with valid JSON array",
@@ -123,6 +197,62 @@ func TestTryUnwrapJSON(t *testing.T) {
 			wantJSON: `{"key":"value"}`,
 		},
 		{
+			name: "CHAR type with JSON object",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "CHAR(1000)"}},
+				Rows:    []map[string]any{{"result": `{"key":"value"}`}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK:   true,
+			wantJSON: `{"key":"value"}`,
+		},
+		{
+			name: "JSON type column",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "JSON"}},
+				Rows:    []map[string]any{{"result": `{"key":"value"}`}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK:   true,
+			wantJSON: `{"key":"value"}`,
+		},
+		{
+			name: "scalar JSON string - no unwrap",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"result": `"hello"`}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
+			name: "scalar JSON number - no unwrap",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"result": `42`}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
+			name: "scalar JSON boolean - no unwrap",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"result": `true`}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
+			name: "scalar JSON null - no unwrap",
+			result: &client.QueryResult{
+				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+				Rows:    []map[string]any{{"result": `null`}},
+				Stats:   client.QueryStats{RowCount: 1},
+			},
+			wantOK: false,
+		},
+		{
 			name: "multiple columns - no unwrap",
 			result: &client.QueryResult{
 				Columns: []client.ColumnInfo{
@@ -135,7 +265,7 @@ func TestTryUnwrapJSON(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name: "single column non-VARCHAR type - no unwrap",
+			name: "single column non-string type - no unwrap",
 			result: &client.QueryResult{
 				Columns: []client.ColumnInfo{{Name: "count", Type: "BIGINT"}},
 				Rows:    []map[string]any{{"count": 42}},
@@ -223,24 +353,8 @@ func TestTryUnwrapJSON(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to marshal parsed result: %v", err)
 				}
-				// Compare as JSON to avoid whitespace differences
-				var expected, actual any
-				if err := json.Unmarshal([]byte(tt.wantJSON), &expected); err != nil {
-					t.Fatalf("failed to unmarshal expected JSON: %v", err)
-				}
-				if err := json.Unmarshal(got, &actual); err != nil {
-					t.Fatalf("failed to unmarshal actual JSON: %v", err)
-				}
-				expectedBytes, errE := json.Marshal(expected)
-				if errE != nil {
-					t.Fatalf("failed to marshal expected: %v", errE)
-				}
-				actualBytes, errA := json.Marshal(actual)
-				if errA != nil {
-					t.Fatalf("failed to marshal actual: %v", errA)
-				}
-				if !bytes.Equal(expectedBytes, actualBytes) {
-					t.Errorf("parsed JSON = %s, want %s", string(actualBytes), string(expectedBytes))
+				if string(got) != tt.wantJSON {
+					t.Errorf("parsed JSON = %s, want %s", string(got), tt.wantJSON)
 				}
 			}
 			if !tt.wantOK && parsed != nil {

--- a/pkg/tools/format_test.go
+++ b/pkg/tools/format_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-
-	"github.com/txn2/mcp-trino/pkg/client"
 )
 
 func TestValidateFormat(t *testing.T) {
@@ -81,18 +79,11 @@ func TestValidateExplainType(t *testing.T) {
 }
 
 func TestFormatOutput(t *testing.T) {
-	result := &client.QueryResult{
-		Columns: []client.ColumnInfo{
-			{Name: "id", Type: "INTEGER"},
-			{Name: "name", Type: "VARCHAR"},
-		},
-		Rows: []map[string]any{
-			{"id": 1, "name": "Alice"},
-		},
-		Stats: client.QueryStats{
-			RowCount:   1,
-			DurationMs: 50,
-		},
+	qo := &QueryOutput{
+		Columns:  []QueryColumn{{Name: "id", Type: "INTEGER"}, {Name: "name", Type: "VARCHAR"}},
+		Rows:     []map[string]any{{"id": 1, "name": "Alice"}},
+		RowCount: 1,
+		Stats:    QueryStats{RowCount: 1, DurationMs: 50},
 	}
 
 	tests := []struct {
@@ -108,7 +99,7 @@ func TestFormatOutput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output, err := formatOutput(result, tt.format)
+			output, err := formatOutput(qo, tt.format)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -118,9 +109,8 @@ func TestFormatOutput(t *testing.T) {
 		})
 	}
 
-	// Verify unsupported format returns error
 	t.Run("unsupported format returns error", func(t *testing.T) {
-		_, err := formatOutput(result, "tsv")
+		_, err := formatOutput(qo, "tsv")
 		if err == nil {
 			t.Error("expected error for unsupported format")
 		}
@@ -159,207 +149,277 @@ func TestIsStringColumnType(t *testing.T) {
 	}
 }
 
-func TestTryUnwrapJSON(t *testing.T) {
+func TestUnwrapJSONColumn(t *testing.T) {
+	t.Run("unwraps JSON object and sets column type", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "result", Type: "VARCHAR"}},
+			Rows:     []map[string]any{{"result": `{"took":2,"count":42}`}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1, DurationMs: 10},
+		}
+
+		unwrapJSONColumn(qo)
+
+		if qo.Columns[0].Type != columnTypeJSON {
+			t.Errorf("expected column type JSON, got %s", qo.Columns[0].Type)
+		}
+		m, ok := qo.Rows[0]["result"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected map[string]any, got %T", qo.Rows[0]["result"])
+		}
+		if m["took"] != float64(2) {
+			t.Errorf("expected took=2, got %v", m["took"])
+		}
+	})
+
+	t.Run("unwraps JSON array", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "data", Type: "VARCHAR"}},
+			Rows:     []map[string]any{{"data": `[1,2,3]`}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1},
+		}
+
+		unwrapJSONColumn(qo)
+
+		if qo.Columns[0].Type != columnTypeJSON {
+			t.Errorf("expected column type JSON, got %s", qo.Columns[0].Type)
+		}
+		arr, ok := qo.Rows[0]["data"].([]any)
+		if !ok {
+			t.Fatalf("expected []any, got %T", qo.Rows[0]["data"])
+		}
+		if len(arr) != 3 {
+			t.Errorf("expected 3 elements, got %d", len(arr))
+		}
+	})
+
+	t.Run("accepts varchar with length constraint", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "r", Type: "varchar(65535)"}},
+			Rows:     []map[string]any{{"r": `{"k":"v"}`}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != columnTypeJSON {
+			t.Errorf("expected JSON, got %s", qo.Columns[0].Type)
+		}
+	})
+
+	t.Run("accepts CHAR type", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "r", Type: "CHAR(1000)"}},
+			Rows:     []map[string]any{{"r": `{"k":"v"}`}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != columnTypeJSON {
+			t.Errorf("expected JSON, got %s", qo.Columns[0].Type)
+		}
+	})
+
+	t.Run("accepts JSON type", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "r", Type: "JSON"}},
+			Rows:     []map[string]any{{"r": `{"k":"v"}`}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != columnTypeJSON {
+			t.Errorf("expected JSON, got %s", qo.Columns[0].Type)
+		}
+	})
+
+	t.Run("no-op for scalar JSON string", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "r", Type: "VARCHAR"}},
+			Rows:     []map[string]any{{"r": `"hello"`}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != "VARCHAR" {
+			t.Errorf("expected VARCHAR unchanged, got %s", qo.Columns[0].Type)
+		}
+	})
+
+	t.Run("no-op for scalar JSON number", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "r", Type: "VARCHAR"}},
+			Rows:     []map[string]any{{"r": `42`}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != "VARCHAR" {
+			t.Errorf("expected VARCHAR unchanged, got %s", qo.Columns[0].Type)
+		}
+	})
+
+	t.Run("no-op for multiple columns", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "id", Type: "INTEGER"}, {Name: "name", Type: "VARCHAR"}},
+			Rows:     []map[string]any{{"id": 1, "name": "Alice"}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != "INTEGER" {
+			t.Errorf("expected INTEGER unchanged, got %s", qo.Columns[0].Type)
+		}
+	})
+
+	t.Run("no-op for multiple rows", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "r", Type: "VARCHAR"}},
+			Rows:     []map[string]any{{"r": `{"a":1}`}, {"r": `{"b":2}`}},
+			RowCount: 2,
+			Stats:    QueryStats{RowCount: 2},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != "VARCHAR" {
+			t.Errorf("expected VARCHAR unchanged, got %s", qo.Columns[0].Type)
+		}
+	})
+
+	t.Run("no-op for non-string type", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "count", Type: "BIGINT"}},
+			Rows:     []map[string]any{{"count": 42}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != "BIGINT" {
+			t.Errorf("expected BIGINT unchanged, got %s", qo.Columns[0].Type)
+		}
+	})
+
+	t.Run("no-op for non-JSON string", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "r", Type: "VARCHAR"}},
+			Rows:     []map[string]any{{"r": "hello world"}},
+			RowCount: 1,
+			Stats:    QueryStats{RowCount: 1},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != "VARCHAR" {
+			t.Errorf("expected VARCHAR unchanged, got %s", qo.Columns[0].Type)
+		}
+		if qo.Rows[0]["r"] != "hello world" {
+			t.Errorf("expected row value unchanged")
+		}
+	})
+
+	t.Run("no-op for zero rows", func(t *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{{Name: "r", Type: "VARCHAR"}},
+			Rows:     []map[string]any{},
+			RowCount: 0,
+			Stats:    QueryStats{RowCount: 0},
+		}
+		unwrapJSONColumn(qo)
+		if qo.Columns[0].Type != "VARCHAR" {
+			t.Errorf("expected VARCHAR unchanged, got %s", qo.Columns[0].Type)
+		}
+	})
+
+	t.Run("no-op for empty columns", func(_ *testing.T) {
+		qo := &QueryOutput{
+			Columns:  []QueryColumn{},
+			Rows:     []map[string]any{},
+			RowCount: 0,
+			Stats:    QueryStats{},
+		}
+		unwrapJSONColumn(qo) // should not panic
+	})
+}
+
+func TestStringifyValue(t *testing.T) {
 	tests := []struct {
 		name     string
-		result   *client.QueryResult
-		wantOK   bool
-		wantJSON string
+		input    any
+		expected string
 	}{
-		{
-			name: "single VARCHAR column with valid JSON object",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"result": `{"took":2,"aggregations":{"count":42}}`}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK:   true,
-			wantJSON: `{"aggregations":{"count":42},"took":2}`,
-		},
-		{
-			name: "single VARCHAR column with valid JSON array",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "data", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"data": `[1,2,3]`}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK:   true,
-			wantJSON: `[1,2,3]`,
-		},
-		{
-			name: "VARCHAR with length constraint",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "varchar(65535)"}},
-				Rows:    []map[string]any{{"result": `{"key":"value"}`}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK:   true,
-			wantJSON: `{"key":"value"}`,
-		},
-		{
-			name: "CHAR type with JSON object",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "CHAR(1000)"}},
-				Rows:    []map[string]any{{"result": `{"key":"value"}`}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK:   true,
-			wantJSON: `{"key":"value"}`,
-		},
-		{
-			name: "JSON type column",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "JSON"}},
-				Rows:    []map[string]any{{"result": `{"key":"value"}`}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK:   true,
-			wantJSON: `{"key":"value"}`,
-		},
-		{
-			name: "scalar JSON string - no unwrap",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"result": `"hello"`}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "scalar JSON number - no unwrap",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"result": `42`}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "scalar JSON boolean - no unwrap",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"result": `true`}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "scalar JSON null - no unwrap",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"result": `null`}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "multiple columns - no unwrap",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{
-					{Name: "id", Type: "INTEGER"},
-					{Name: "name", Type: "VARCHAR"},
-				},
-				Rows:  []map[string]any{{"id": 1, "name": "Alice"}},
-				Stats: client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "single column non-string type - no unwrap",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "count", Type: "BIGINT"}},
-				Rows:    []map[string]any{{"count": 42}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "multiple rows - no unwrap",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows: []map[string]any{
-					{"result": `{"a":1}`},
-					{"result": `{"b":2}`},
-				},
-				Stats: client.QueryStats{RowCount: 2},
-			},
-			wantOK: false,
-		},
-		{
-			name: "zero rows - no unwrap",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{},
-				Stats:   client.QueryStats{RowCount: 0},
-			},
-			wantOK: false,
-		},
-		{
-			name: "single VARCHAR column with non-JSON string",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"result": "hello world"}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "single VARCHAR column with empty string",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"result": ""}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "single VARCHAR column with nil value",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"result": nil}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "single VARCHAR column with non-string value",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
-				Rows:    []map[string]any{{"result": 42}},
-				Stats:   client.QueryStats{RowCount: 1},
-			},
-			wantOK: false,
-		},
-		{
-			name: "no columns - no unwrap",
-			result: &client.QueryResult{
-				Columns: []client.ColumnInfo{},
-				Rows:    []map[string]any{},
-				Stats:   client.QueryStats{},
-			},
-			wantOK: false,
-		},
+		{"string", "hello", "hello"},
+		{"int", 42, "42"},
+		{"nil", nil, "<nil>"},
+		{"map", map[string]any{"k": "v"}, `{"k":"v"}`},
+		{"slice", []any{1, 2, 3}, `[1,2,3]`},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsed, ok := tryUnwrapJSON(tt.result)
-			if ok != tt.wantOK {
-				t.Errorf("tryUnwrapJSON() ok = %v, want %v", ok, tt.wantOK)
-				return
-			}
-			if tt.wantOK && tt.wantJSON != "" {
-				got, err := json.Marshal(parsed)
-				if err != nil {
-					t.Fatalf("failed to marshal parsed result: %v", err)
-				}
-				if string(got) != tt.wantJSON {
-					t.Errorf("parsed JSON = %s, want %s", string(got), tt.wantJSON)
-				}
-			}
-			if !tt.wantOK && parsed != nil {
-				t.Errorf("expected nil parsed result when ok is false, got %v", parsed)
+			got := stringifyValue(tt.input)
+			if got != tt.expected {
+				t.Errorf("stringifyValue(%v) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestUnwrapJSONColumn_JSONFormatOutput(t *testing.T) {
+	// Verify that after unwrap, JSON output contains the parsed object inline
+	// and the column type is "JSON" — same envelope, no double-encoding.
+	qo := &QueryOutput{
+		Columns:  []QueryColumn{{Name: "result", Type: "VARCHAR"}},
+		Rows:     []map[string]any{{"result": `{"took":2,"aggs":{"count":42}}`}},
+		RowCount: 1,
+		Stats:    QueryStats{RowCount: 1, DurationMs: 10},
+	}
+
+	unwrapJSONColumn(qo)
+
+	output, err := formatOutput(qo, "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The JSON output should contain the parsed object inline (no escaping)
+	if strings.Contains(output, `\"took\"`) {
+		t.Error("JSON output still contains escaped quotes — value was not unwrapped")
+	}
+	if !strings.Contains(output, `"took"`) {
+		t.Error("JSON output should contain the unwrapped 'took' field")
+	}
+	if !strings.Contains(output, `"type": "JSON"`) {
+		t.Error("JSON output should show column type as JSON")
+	}
+
+	// Verify round-trip: parse the output and check structure
+	var parsed QueryOutput
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("failed to parse JSON output: %v", err)
+	}
+	if parsed.Columns[0].Type != "JSON" {
+		t.Errorf("expected column type JSON, got %s", parsed.Columns[0].Type)
+	}
+	if parsed.Stats.DurationMs != 10 {
+		t.Errorf("expected duration_ms=10, got %d", parsed.Stats.DurationMs)
+	}
+}
+
+func TestUnwrapJSONColumn_CSVFormatOutput(t *testing.T) {
+	// After unwrap, CSV should contain the compact JSON string
+	qo := &QueryOutput{
+		Columns:  []QueryColumn{{Name: "result", Type: "VARCHAR"}},
+		Rows:     []map[string]any{{"result": `{"key":"value"}`}},
+		RowCount: 1,
+		Stats:    QueryStats{RowCount: 1, DurationMs: 5},
+	}
+
+	unwrapJSONColumn(qo)
+
+	output, err := formatOutput(qo, "csv")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// CSV should contain the compact JSON as a quoted value
+	if !strings.Contains(output, `"key"`) {
+		t.Errorf("CSV output should contain JSON key, got:\n%s", output)
 	}
 }

--- a/pkg/tools/handlers_test.go
+++ b/pkg/tools/handlers_test.go
@@ -1115,6 +1115,163 @@ func TestHandleExecute_ConnectionError(t *testing.T) {
 	}
 }
 
+// TestHandleQuery_InvalidFormat tests that invalid format values return an error.
+func TestHandleQuery_InvalidFormat(t *testing.T) {
+	mock := NewMockTrinoClient()
+	toolkit := NewToolkit(mock, DefaultConfig())
+
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{"uppercase JSON", "JSON"},
+		{"tsv", "tsv"},
+		{"table", "table"},
+		{"ndjson", "ndjson"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _, err := toolkit.handleQuery(context.Background(), nil, QueryInput{
+				SQL:    "SELECT 1",
+				Format: tt.format,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.IsError {
+				t.Error("expected error result for invalid format")
+			}
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("expected TextContent")
+			}
+			if !strings.Contains(textContent.Text, "invalid format") {
+				t.Errorf("expected 'invalid format' in error, got: %s", textContent.Text)
+			}
+		})
+	}
+}
+
+// TestHandleExecute_InvalidFormat tests that invalid format values return an error.
+func TestHandleExecute_InvalidFormat(t *testing.T) {
+	mock := NewMockTrinoClient()
+	toolkit := NewToolkit(mock, DefaultConfig())
+
+	result, _, err := toolkit.handleExecute(context.Background(), nil, ExecuteInput{
+		SQL:    "SELECT 1",
+		Format: "tsv",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for invalid format")
+	}
+}
+
+// TestHandleQuery_UnwrapJSON tests JSON unwrapping for single-row VARCHAR results.
+func TestHandleQuery_UnwrapJSON(t *testing.T) {
+	mock := NewMockTrinoClient()
+	mock.QueryFunc = func(_ context.Context, _ string, _ client.QueryOptions) (*client.QueryResult, error) {
+		return &client.QueryResult{
+			Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+			Rows:    []map[string]any{{"result": `{"took":2,"count":42}`}},
+			Stats:   client.QueryStats{RowCount: 1, DurationMs: 10},
+		}, nil
+	}
+	toolkit := NewToolkit(mock, DefaultConfig())
+
+	// Without unwrap_json, no unwrapped_result in output
+	_, output, err := toolkit.handleQuery(context.Background(), nil, QueryInput{
+		SQL:        "SELECT * FROM TABLE(raw_query())",
+		UnwrapJSON: false,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	qo, ok := output.(*QueryOutput)
+	if !ok {
+		t.Fatal("expected *QueryOutput")
+	}
+	if qo.UnwrappedResult != nil {
+		t.Error("expected nil UnwrappedResult when unwrap_json is false")
+	}
+
+	// With unwrap_json, unwrapped_result should be present
+	_, output, err = toolkit.handleQuery(context.Background(), nil, QueryInput{
+		SQL:        "SELECT * FROM TABLE(raw_query())",
+		UnwrapJSON: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	qo, ok = output.(*QueryOutput)
+	if !ok {
+		t.Fatal("expected *QueryOutput")
+	}
+	if qo.UnwrappedResult == nil {
+		t.Fatal("expected non-nil UnwrappedResult when unwrap_json is true")
+	}
+	// Verify the parsed result has the expected structure
+	m, ok := qo.UnwrappedResult.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", qo.UnwrappedResult)
+	}
+	if m["took"] != float64(2) {
+		t.Errorf("expected took=2, got %v", m["took"])
+	}
+}
+
+// TestHandleQuery_UnwrapJSON_NoMatch tests that unwrap_json is a no-op for non-matching results.
+func TestHandleQuery_UnwrapJSON_NoMatch(t *testing.T) {
+	mock := NewMockTrinoClient() // Default mock returns 2 columns
+	toolkit := NewToolkit(mock, DefaultConfig())
+
+	_, output, err := toolkit.handleQuery(context.Background(), nil, QueryInput{
+		SQL:        "SELECT * FROM users",
+		UnwrapJSON: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	qo, ok := output.(*QueryOutput)
+	if !ok {
+		t.Fatal("expected *QueryOutput")
+	}
+	if qo.UnwrappedResult != nil {
+		t.Error("expected nil UnwrappedResult for multi-column result")
+	}
+}
+
+// TestHandleExecute_UnwrapJSON tests JSON unwrapping in trino_execute.
+func TestHandleExecute_UnwrapJSON(t *testing.T) {
+	mock := NewMockTrinoClient()
+	mock.QueryFunc = func(_ context.Context, _ string, _ client.QueryOptions) (*client.QueryResult, error) {
+		return &client.QueryResult{
+			Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+			Rows:    []map[string]any{{"result": `[1,2,3]`}},
+			Stats:   client.QueryStats{RowCount: 1, DurationMs: 5},
+		}, nil
+	}
+	toolkit := NewToolkit(mock, DefaultConfig())
+
+	_, output, err := toolkit.handleExecute(context.Background(), nil, ExecuteInput{
+		SQL:        "SELECT * FROM TABLE(raw_query())",
+		UnwrapJSON: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	qo, ok := output.(*QueryOutput)
+	if !ok {
+		t.Fatal("expected *QueryOutput")
+	}
+	if qo.UnwrappedResult == nil {
+		t.Fatal("expected non-nil UnwrappedResult")
+	}
+}
+
 // TestRegisteredToolInvocation exercises the full registration + MCP dispatch path
 // for all tools, covering the typed-output wrapper closures in register*Tool functions.
 func TestRegisteredToolInvocation(t *testing.T) {

--- a/pkg/tools/handlers_test.go
+++ b/pkg/tools/handlers_test.go
@@ -1183,7 +1183,7 @@ func TestHandleQuery_UnwrapJSON(t *testing.T) {
 	toolkit := NewToolkit(mock, DefaultConfig())
 
 	// Without unwrap_json, no unwrapped_result in output
-	_, output, err := toolkit.handleQuery(context.Background(), nil, QueryInput{
+	result, output, err := toolkit.handleQuery(context.Background(), nil, QueryInput{
 		SQL:        "SELECT * FROM TABLE(raw_query())",
 		UnwrapJSON: false,
 	})
@@ -1197,9 +1197,17 @@ func TestHandleQuery_UnwrapJSON(t *testing.T) {
 	if qo.UnwrappedResult != nil {
 		t.Error("expected nil UnwrappedResult when unwrap_json is false")
 	}
+	// Text content should NOT contain unwrapped_result
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatal("expected TextContent")
+	}
+	if strings.Contains(textContent.Text, "unwrapped_result") {
+		t.Error("text content should not contain unwrapped_result when unwrap_json is false")
+	}
 
-	// With unwrap_json, unwrapped_result should be present
-	_, output, err = toolkit.handleQuery(context.Background(), nil, QueryInput{
+	// With unwrap_json, unwrapped_result should be present in both structured and text output
+	result, output, err = toolkit.handleQuery(context.Background(), nil, QueryInput{
 		SQL:        "SELECT * FROM TABLE(raw_query())",
 		UnwrapJSON: true,
 	})
@@ -1220,6 +1228,17 @@ func TestHandleQuery_UnwrapJSON(t *testing.T) {
 	}
 	if m["took"] != float64(2) {
 		t.Errorf("expected took=2, got %v", m["took"])
+	}
+	// Text content MUST contain the unwrapped JSON (issue #1: text content must reflect unwrap)
+	textContent, ok = result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatal("expected TextContent")
+	}
+	if !strings.Contains(textContent.Text, "unwrapped_result") {
+		t.Error("text content should contain unwrapped_result when unwrap succeeds")
+	}
+	if !strings.Contains(textContent.Text, `"took"`) {
+		t.Error("text content should contain the unwrapped JSON fields")
 	}
 }
 
@@ -1244,6 +1263,84 @@ func TestHandleQuery_UnwrapJSON_NoMatch(t *testing.T) {
 	}
 }
 
+// TestHandleQuery_UnwrapJSON_WithCSVFormat tests that unwrap populates structured output
+// but CSV text content is unchanged (unwrap only affects JSON text output).
+func TestHandleQuery_UnwrapJSON_WithCSVFormat(t *testing.T) {
+	mock := NewMockTrinoClient()
+	mock.QueryFunc = func(_ context.Context, _ string, _ client.QueryOptions) (*client.QueryResult, error) {
+		return &client.QueryResult{
+			Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+			Rows:    []map[string]any{{"result": `{"key":"value"}`}},
+			Stats:   client.QueryStats{RowCount: 1, DurationMs: 5},
+		}, nil
+	}
+	toolkit := NewToolkit(mock, DefaultConfig())
+
+	result, output, err := toolkit.handleQuery(context.Background(), nil, QueryInput{
+		SQL:        "SELECT * FROM TABLE(raw_query())",
+		Format:     "csv",
+		UnwrapJSON: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Structured output should have unwrapped result
+	qo, ok := output.(*QueryOutput)
+	if !ok {
+		t.Fatal("expected *QueryOutput")
+	}
+	if qo.UnwrappedResult == nil {
+		t.Fatal("expected non-nil UnwrappedResult even with CSV format")
+	}
+
+	// Text content should be CSV (not JSON with unwrapped_result)
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatal("expected TextContent")
+	}
+	if !strings.Contains(textContent.Text, "result") {
+		t.Error("expected CSV header")
+	}
+	if strings.Contains(textContent.Text, "unwrapped_result") {
+		t.Error("CSV text should not contain unwrapped_result field")
+	}
+}
+
+// TestHandleQuery_UnwrapJSON_ScalarNoMatch tests that scalar JSON values are not unwrapped.
+func TestHandleQuery_UnwrapJSON_ScalarNoMatch(t *testing.T) {
+	scalars := []string{`"hello"`, `42`, `true`, `null`}
+
+	for _, scalar := range scalars {
+		t.Run("scalar_"+scalar, func(t *testing.T) {
+			mock := NewMockTrinoClient()
+			mock.QueryFunc = func(_ context.Context, _ string, _ client.QueryOptions) (*client.QueryResult, error) {
+				return &client.QueryResult{
+					Columns: []client.ColumnInfo{{Name: "result", Type: "VARCHAR"}},
+					Rows:    []map[string]any{{"result": scalar}},
+					Stats:   client.QueryStats{RowCount: 1, DurationMs: 5},
+				}, nil
+			}
+			toolkit := NewToolkit(mock, DefaultConfig())
+
+			_, output, err := toolkit.handleQuery(context.Background(), nil, QueryInput{
+				SQL:        "SELECT result",
+				UnwrapJSON: true,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			qo, ok := output.(*QueryOutput)
+			if !ok {
+				t.Fatal("expected *QueryOutput")
+			}
+			if qo.UnwrappedResult != nil {
+				t.Errorf("expected nil UnwrappedResult for scalar JSON %s", scalar)
+			}
+		})
+	}
+}
+
 // TestHandleExecute_UnwrapJSON tests JSON unwrapping in trino_execute.
 func TestHandleExecute_UnwrapJSON(t *testing.T) {
 	mock := NewMockTrinoClient()
@@ -1256,7 +1353,7 @@ func TestHandleExecute_UnwrapJSON(t *testing.T) {
 	}
 	toolkit := NewToolkit(mock, DefaultConfig())
 
-	_, output, err := toolkit.handleExecute(context.Background(), nil, ExecuteInput{
+	result, output, err := toolkit.handleExecute(context.Background(), nil, ExecuteInput{
 		SQL:        "SELECT * FROM TABLE(raw_query())",
 		UnwrapJSON: true,
 	})
@@ -1269,6 +1366,51 @@ func TestHandleExecute_UnwrapJSON(t *testing.T) {
 	}
 	if qo.UnwrappedResult == nil {
 		t.Fatal("expected non-nil UnwrappedResult")
+	}
+	// Text content must also reflect the unwrap
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatal("expected TextContent")
+	}
+	if !strings.Contains(textContent.Text, "unwrapped_result") {
+		t.Error("text content should contain unwrapped_result when unwrap succeeds")
+	}
+}
+
+// TestHandleExplain_InvalidType tests that invalid explain type values return an error.
+func TestHandleExplain_InvalidType(t *testing.T) {
+	mock := NewMockTrinoClient()
+	toolkit := NewToolkit(mock, DefaultConfig())
+
+	tests := []struct {
+		name string
+		typ  string
+	}{
+		{"uppercase LOGICAL", "LOGICAL"},
+		{"unknown type", "unknown"},
+		{"verbose", "verbose"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _, err := toolkit.handleExplain(context.Background(), nil, ExplainInput{
+				SQL:  "SELECT 1",
+				Type: tt.typ,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.IsError {
+				t.Error("expected error result for invalid explain type")
+			}
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatal("expected TextContent")
+			}
+			if !strings.Contains(textContent.Text, "invalid explain type") {
+				t.Errorf("expected 'invalid explain type' in error, got: %s", textContent.Text)
+			}
+		})
 	}
 }
 

--- a/pkg/tools/handlers_test.go
+++ b/pkg/tools/handlers_test.go
@@ -1182,7 +1182,7 @@ func TestHandleQuery_UnwrapJSON(t *testing.T) {
 	}
 	toolkit := NewToolkit(mock, DefaultConfig())
 
-	// Without unwrap_json, no unwrapped_result in output
+	// Without unwrap_json, column type stays VARCHAR and value stays a string
 	result, output, err := toolkit.handleQuery(context.Background(), nil, QueryInput{
 		SQL:        "SELECT * FROM TABLE(raw_query())",
 		UnwrapJSON: false,
@@ -1194,19 +1194,22 @@ func TestHandleQuery_UnwrapJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("expected *QueryOutput")
 	}
-	if qo.UnwrappedResult != nil {
-		t.Error("expected nil UnwrappedResult when unwrap_json is false")
+	if qo.Columns[0].Type != "VARCHAR" {
+		t.Errorf("expected VARCHAR, got %s", qo.Columns[0].Type)
 	}
-	// Text content should NOT contain unwrapped_result
+	if _, isStr := qo.Rows[0]["result"].(string); !isStr {
+		t.Errorf("expected string value when unwrap_json is false, got %T", qo.Rows[0]["result"])
+	}
+	// Text content should contain escaped JSON (double-encoded)
 	textContent, ok := result.Content[0].(*mcp.TextContent)
 	if !ok {
 		t.Fatal("expected TextContent")
 	}
-	if strings.Contains(textContent.Text, "unwrapped_result") {
-		t.Error("text content should not contain unwrapped_result when unwrap_json is false")
+	if !strings.Contains(textContent.Text, `\"took\"`) {
+		t.Error("without unwrap, text should contain escaped JSON string")
 	}
 
-	// With unwrap_json, unwrapped_result should be present in both structured and text output
+	// With unwrap_json, column type becomes JSON and value is parsed object
 	result, output, err = toolkit.handleQuery(context.Background(), nil, QueryInput{
 		SQL:        "SELECT * FROM TABLE(raw_query())",
 		UnwrapJSON: true,
@@ -1218,27 +1221,30 @@ func TestHandleQuery_UnwrapJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("expected *QueryOutput")
 	}
-	if qo.UnwrappedResult == nil {
-		t.Fatal("expected non-nil UnwrappedResult when unwrap_json is true")
+	if qo.Columns[0].Type != columnTypeJSON {
+		t.Errorf("expected column type JSON, got %s", qo.Columns[0].Type)
 	}
-	// Verify the parsed result has the expected structure
-	m, ok := qo.UnwrappedResult.(map[string]any)
+	m, ok := qo.Rows[0]["result"].(map[string]any)
 	if !ok {
-		t.Fatalf("expected map[string]any, got %T", qo.UnwrappedResult)
+		t.Fatalf("expected map[string]any, got %T", qo.Rows[0]["result"])
 	}
 	if m["took"] != float64(2) {
 		t.Errorf("expected took=2, got %v", m["took"])
 	}
-	// Text content MUST contain the unwrapped JSON (issue #1: text content must reflect unwrap)
+	// Text content should contain the parsed JSON inline (not escaped)
 	textContent, ok = result.Content[0].(*mcp.TextContent)
 	if !ok {
 		t.Fatal("expected TextContent")
 	}
-	if !strings.Contains(textContent.Text, "unwrapped_result") {
-		t.Error("text content should contain unwrapped_result when unwrap succeeds")
+	if strings.Contains(textContent.Text, `\"took\"`) {
+		t.Error("with unwrap, text should NOT contain escaped JSON")
 	}
 	if !strings.Contains(textContent.Text, `"took"`) {
-		t.Error("text content should contain the unwrapped JSON fields")
+		t.Error("with unwrap, text should contain the parsed JSON field")
+	}
+	// Envelope shape is the same — columns, rows, stats, no extra fields
+	if strings.Contains(textContent.Text, "unwrapped_result") {
+		t.Error("should not have an unwrapped_result field — value is inline in rows")
 	}
 }
 
@@ -1258,13 +1264,13 @@ func TestHandleQuery_UnwrapJSON_NoMatch(t *testing.T) {
 	if !ok {
 		t.Fatal("expected *QueryOutput")
 	}
-	if qo.UnwrappedResult != nil {
-		t.Error("expected nil UnwrappedResult for multi-column result")
+	// Column types should be unchanged
+	if qo.Columns[0].Type != "INTEGER" {
+		t.Errorf("expected INTEGER unchanged, got %s", qo.Columns[0].Type)
 	}
 }
 
-// TestHandleQuery_UnwrapJSON_WithCSVFormat tests that unwrap populates structured output
-// but CSV text content is unchanged (unwrap only affects JSON text output).
+// TestHandleQuery_UnwrapJSON_WithCSVFormat tests that unwrap affects CSV output too.
 func TestHandleQuery_UnwrapJSON_WithCSVFormat(t *testing.T) {
 	mock := NewMockTrinoClient()
 	mock.QueryFunc = func(_ context.Context, _ string, _ client.QueryOptions) (*client.QueryResult, error) {
@@ -1285,16 +1291,16 @@ func TestHandleQuery_UnwrapJSON_WithCSVFormat(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Structured output should have unwrapped result
+	// Structured output should have column type JSON
 	qo, ok := output.(*QueryOutput)
 	if !ok {
 		t.Fatal("expected *QueryOutput")
 	}
-	if qo.UnwrappedResult == nil {
-		t.Fatal("expected non-nil UnwrappedResult even with CSV format")
+	if qo.Columns[0].Type != columnTypeJSON {
+		t.Errorf("expected JSON column type, got %s", qo.Columns[0].Type)
 	}
 
-	// Text content should be CSV (not JSON with unwrapped_result)
+	// Text content should be CSV with compact JSON value
 	textContent, ok := result.Content[0].(*mcp.TextContent)
 	if !ok {
 		t.Fatal("expected TextContent")
@@ -1302,8 +1308,8 @@ func TestHandleQuery_UnwrapJSON_WithCSVFormat(t *testing.T) {
 	if !strings.Contains(textContent.Text, "result") {
 		t.Error("expected CSV header")
 	}
-	if strings.Contains(textContent.Text, "unwrapped_result") {
-		t.Error("CSV text should not contain unwrapped_result field")
+	if !strings.Contains(textContent.Text, `"key"`) {
+		t.Error("CSV should contain the compact JSON value")
 	}
 }
 
@@ -1334,8 +1340,8 @@ func TestHandleQuery_UnwrapJSON_ScalarNoMatch(t *testing.T) {
 			if !ok {
 				t.Fatal("expected *QueryOutput")
 			}
-			if qo.UnwrappedResult != nil {
-				t.Errorf("expected nil UnwrappedResult for scalar JSON %s", scalar)
+			if qo.Columns[0].Type != "VARCHAR" {
+				t.Errorf("expected VARCHAR unchanged for scalar %s, got %s", scalar, qo.Columns[0].Type)
 			}
 		})
 	}
@@ -1364,16 +1370,19 @@ func TestHandleExecute_UnwrapJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("expected *QueryOutput")
 	}
-	if qo.UnwrappedResult == nil {
-		t.Fatal("expected non-nil UnwrappedResult")
+	if qo.Columns[0].Type != columnTypeJSON {
+		t.Errorf("expected JSON column type, got %s", qo.Columns[0].Type)
 	}
-	// Text content must also reflect the unwrap
+	if _, isArr := qo.Rows[0]["result"].([]any); !isArr {
+		t.Errorf("expected []any, got %T", qo.Rows[0]["result"])
+	}
+	// Text content should show parsed array inline
 	textContent, ok := result.Content[0].(*mcp.TextContent)
 	if !ok {
 		t.Fatal("expected TextContent")
 	}
-	if !strings.Contains(textContent.Text, "unwrapped_result") {
-		t.Error("text content should contain unwrapped_result when unwrap succeeds")
+	if !strings.Contains(textContent.Text, `"type": "JSON"`) {
+		t.Error("text content should show column type as JSON")
 	}
 }
 

--- a/pkg/tools/outputs.go
+++ b/pkg/tools/outputs.go
@@ -6,10 +6,6 @@ type QueryOutput struct {
 	Rows     []map[string]any `json:"rows"`
 	RowCount int              `json:"row_count"`
 	Stats    QueryStats       `json:"stats"`
-
-	// UnwrappedResult contains the parsed JSON when unwrap_json is true and
-	// the result matches the (1 row, 1 string column, valid JSON object/array) shape.
-	UnwrappedResult any `json:"unwrapped_result,omitempty"`
 }
 
 // QueryColumn describes a column in the query result.

--- a/pkg/tools/outputs.go
+++ b/pkg/tools/outputs.go
@@ -2,10 +2,11 @@ package tools
 
 // QueryOutput defines the structured output of the trino_query tool.
 type QueryOutput struct {
-	Columns  []QueryColumn    `json:"columns"`
-	Rows     []map[string]any `json:"rows"`
-	RowCount int              `json:"row_count"`
-	Stats    QueryStats       `json:"stats"`
+	Columns         []QueryColumn    `json:"columns"`
+	Rows            []map[string]any `json:"rows"`
+	RowCount        int              `json:"row_count"`
+	Stats           QueryStats       `json:"stats"`
+	UnwrappedResult any              `json:"unwrapped_result,omitempty"`
 }
 
 // QueryColumn describes a column in the query result.

--- a/pkg/tools/outputs.go
+++ b/pkg/tools/outputs.go
@@ -2,11 +2,14 @@ package tools
 
 // QueryOutput defines the structured output of the trino_query tool.
 type QueryOutput struct {
-	Columns         []QueryColumn    `json:"columns"`
-	Rows            []map[string]any `json:"rows"`
-	RowCount        int              `json:"row_count"`
-	Stats           QueryStats       `json:"stats"`
-	UnwrappedResult any              `json:"unwrapped_result,omitempty"`
+	Columns  []QueryColumn    `json:"columns"`
+	Rows     []map[string]any `json:"rows"`
+	RowCount int              `json:"row_count"`
+	Stats    QueryStats       `json:"stats"`
+
+	// UnwrappedResult contains the parsed JSON when unwrap_json is true and
+	// the result matches the (1 row, 1 string column, valid JSON object/array) shape.
+	UnwrappedResult any `json:"unwrapped_result,omitempty"`
 }
 
 // QueryColumn describes a column in the query result.

--- a/pkg/tools/query.go
+++ b/pkg/tools/query.go
@@ -207,29 +207,3 @@ func buildQueryOutput(r *client.QueryResult) QueryOutput {
 		},
 	}
 }
-
-// escapeCSV escapes a value for CSV output.
-func escapeCSV(s string) string {
-	needsQuoting := false
-	for _, c := range s {
-		if c == ',' || c == '"' || c == '\n' || c == '\r' {
-			needsQuoting = true
-			break
-		}
-	}
-	if !needsQuoting {
-		return s
-	}
-
-	// Escape quotes and wrap in quotes
-	result := "\""
-	for _, c := range s {
-		if c == '"' {
-			result += "\"\""
-		} else {
-			result += string(c)
-		}
-	}
-	result += "\""
-	return result
-}

--- a/pkg/tools/query.go
+++ b/pkg/tools/query.go
@@ -45,10 +45,10 @@ type QueryInput struct {
 	// Format is the output format: json (default), csv, or markdown.
 	Format string `json:"format,omitempty" jsonschema_description:"Output format: json, csv, or markdown (default: json)"`
 
-	// UnwrapJSON controls automatic JSON unwrapping for single-row, single-VARCHAR-column results.
-	// When true and the result is exactly one row with one VARCHAR column containing valid JSON,
-	// the parsed JSON is included in the response as unwrapped_result.
-	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-VARCHAR-column containing valid JSON, include parsed JSON as unwrapped_result"` //nolint:lll // jsonschema_description must be a single tag value
+	// UnwrapJSON controls automatic JSON unwrapping for single-row, single-string-column results.
+	// When true and the result matches, the column type is changed to "JSON" and the row value
+	// is replaced with the parsed object. The envelope shape is unchanged.
+	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-string-column containing a JSON object or array, parse the value inline and set column type to JSON"` //nolint:lll // jsonschema_description must be a single tag value
 
 	// Connection is the named connection to use. Empty uses the default connection.
 	// Use trino_list_connections to see available connections.
@@ -157,15 +157,14 @@ func (t *Toolkit) handleQuery(ctx context.Context, _ *mcp.CallToolRequest, input
 	// Build structured output
 	queryOutput := buildQueryOutput(result)
 
-	// Attempt JSON unwrap if requested
+	// Attempt JSON unwrap if requested — mutates queryOutput in place,
+	// changing columns[0].type to "JSON" and replacing the row value.
 	if input.UnwrapJSON {
-		if parsed, ok := tryUnwrapJSON(result); ok {
-			queryOutput.UnwrappedResult = parsed
-		}
+		unwrapJSONColumn(&queryOutput)
 	}
 
-	// Render text content
-	output, err := renderTextContent(result, &queryOutput, input.Format)
+	// Format output
+	output, err := formatOutput(&queryOutput, input.Format)
 	if err != nil {
 		return ErrorResult(err.Error()), nil, nil
 	}
@@ -207,90 +206,6 @@ func buildQueryOutput(r *client.QueryResult) QueryOutput {
 			DurationMs:   r.Stats.DurationMs,
 		},
 	}
-}
-
-// formatCSV formats query results as CSV.
-func formatCSV(result *client.QueryResult) string {
-	if len(result.Columns) == 0 {
-		return ""
-	}
-
-	var output string
-
-	// Header row
-	for i, col := range result.Columns {
-		if i > 0 {
-			output += ","
-		}
-		output += escapeCSV(col.Name)
-	}
-	output += "\n"
-
-	// Data rows
-	for _, row := range result.Rows {
-		for i, col := range result.Columns {
-			if i > 0 {
-				output += ","
-			}
-			if val, ok := row[col.Name]; ok {
-				output += escapeCSV(fmt.Sprintf("%v", val))
-			}
-		}
-		output += "\n"
-	}
-
-	// Stats footer
-	output += fmt.Sprintf("\n# %d rows returned", result.Stats.RowCount)
-	if result.Stats.Truncated {
-		output += fmt.Sprintf(" (truncated at limit %d)", result.Stats.LimitApplied)
-	}
-	output += fmt.Sprintf(", executed in %dms", result.Stats.DurationMs)
-
-	return output
-}
-
-// formatMarkdown formats query results as a Markdown table.
-func formatMarkdown(result *client.QueryResult) string {
-	if len(result.Columns) == 0 {
-		return "No results"
-	}
-
-	var output string
-
-	// Header row
-	output += "|"
-	for _, col := range result.Columns {
-		output += " " + col.Name + " |"
-	}
-	output += "\n|"
-
-	// Separator row
-	for range result.Columns {
-		output += " --- |"
-	}
-	output += "\n"
-
-	// Data rows
-	for _, row := range result.Rows {
-		output += "|"
-		for _, col := range result.Columns {
-			val := ""
-			if v, ok := row[col.Name]; ok && v != nil {
-				val = fmt.Sprintf("%v", v)
-			}
-			output += " " + val + " |"
-		}
-		output += "\n"
-	}
-
-	// Stats footer
-	output += fmt.Sprintf("\n*%d rows returned", result.Stats.RowCount)
-	if result.Stats.Truncated {
-		output += fmt.Sprintf(" (truncated at limit %d)", result.Stats.LimitApplied)
-	}
-	output += fmt.Sprintf(", executed in %dms*", result.Stats.DurationMs)
-
-	return output
 }
 
 // escapeCSV escapes a value for CSV output.

--- a/pkg/tools/query.go
+++ b/pkg/tools/query.go
@@ -48,8 +48,7 @@ type QueryInput struct {
 	// UnwrapJSON controls automatic JSON unwrapping for single-row, single-VARCHAR-column results.
 	// When true and the result is exactly one row with one VARCHAR column containing valid JSON,
 	// the parsed JSON is included in the response as unwrapped_result.
-	//nolint:lll // jsonschema_description must be a single tag value
-	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-VARCHAR-column containing valid JSON, include parsed JSON as unwrapped_result"`
+	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-VARCHAR-column containing valid JSON, include parsed JSON as unwrapped_result"` //nolint:lll // jsonschema_description must be a single tag value
 
 	// Connection is the named connection to use. Empty uses the default connection.
 	// Use trino_list_connections to see available connections.
@@ -155,15 +154,6 @@ func (t *Toolkit) handleQuery(ctx context.Context, _ *mcp.CallToolRequest, input
 	notifyProgress(ctx, notifier, 1, 3,
 		fmt.Sprintf("Query returned %d rows, formatting...", result.Stats.RowCount))
 
-	// Format output
-	output, err := formatOutput(result, input.Format)
-	if err != nil {
-		return ErrorResult(err.Error()), nil, nil
-	}
-
-	// Send progress notification: query complete
-	notifyProgress(ctx, notifier, 2, 3, "Query complete")
-
 	// Build structured output
 	queryOutput := buildQueryOutput(result)
 
@@ -173,6 +163,15 @@ func (t *Toolkit) handleQuery(ctx context.Context, _ *mcp.CallToolRequest, input
 			queryOutput.UnwrappedResult = parsed
 		}
 	}
+
+	// Render text content
+	output, err := renderTextContent(result, &queryOutput, input.Format)
+	if err != nil {
+		return ErrorResult(err.Error()), nil, nil
+	}
+
+	// Send progress notification: query complete
+	notifyProgress(ctx, notifier, 2, 3, "Query complete")
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/pkg/tools/query.go
+++ b/pkg/tools/query.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -46,6 +45,12 @@ type QueryInput struct {
 	// Format is the output format: json (default), csv, or markdown.
 	Format string `json:"format,omitempty" jsonschema_description:"Output format: json, csv, or markdown (default: json)"`
 
+	// UnwrapJSON controls automatic JSON unwrapping for single-row, single-VARCHAR-column results.
+	// When true and the result is exactly one row with one VARCHAR column containing valid JSON,
+	// the parsed JSON is included in the response as unwrapped_result.
+	//nolint:lll // jsonschema_description must be a single tag value
+	UnwrapJSON bool `json:"unwrap_json,omitempty" jsonschema_description:"When true and result is a single-row single-VARCHAR-column containing valid JSON, include parsed JSON as unwrapped_result"`
+
 	// Connection is the named connection to use. Empty uses the default connection.
 	// Use trino_list_connections to see available connections.
 	Connection string `json:"connection,omitempty" jsonschema_description:"Named connection to use (see trino_list_connections)"`
@@ -87,6 +92,11 @@ func (t *Toolkit) handleQuery(ctx context.Context, _ *mcp.CallToolRequest, input
 	// Validate SQL is provided
 	if input.SQL == "" {
 		return ErrorResult("sql parameter is required"), nil, nil
+	}
+
+	// Validate format
+	if err := validateFormat(input.Format); err != nil {
+		return ErrorResult(err.Error()), nil, nil
 	}
 
 	// Enforce read-only: trino_query only allows read operations.
@@ -146,23 +156,9 @@ func (t *Toolkit) handleQuery(ctx context.Context, _ *mcp.CallToolRequest, input
 		fmt.Sprintf("Query returned %d rows, formatting...", result.Stats.RowCount))
 
 	// Format output
-	format := input.Format
-	if format == "" {
-		format = "json"
-	}
-
-	var output string
-	switch format {
-	case "csv":
-		output = formatCSV(result)
-	case "markdown":
-		output = formatMarkdown(result)
-	default:
-		data, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return ErrorResult(fmt.Sprintf("Failed to marshal result: %v", err)), nil, nil
-		}
-		output = string(data)
+	output, err := formatOutput(result, input.Format)
+	if err != nil {
+		return ErrorResult(err.Error()), nil, nil
 	}
 
 	// Send progress notification: query complete
@@ -170,6 +166,13 @@ func (t *Toolkit) handleQuery(ctx context.Context, _ *mcp.CallToolRequest, input
 
 	// Build structured output
 	queryOutput := buildQueryOutput(result)
+
+	// Attempt JSON unwrap if requested
+	if input.UnwrapJSON {
+		if parsed, ok := tryUnwrapJSON(result); ok {
+			queryOutput.UnwrappedResult = parsed
+		}
+	}
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/pkg/tools/query_test.go
+++ b/pkg/tools/query_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/txn2/mcp-trino/pkg/client"
 )
 
+// toQueryOutput converts a client.QueryResult to a QueryOutput for testing.
+func toQueryOutput(r *client.QueryResult) *QueryOutput {
+	qo := buildQueryOutput(r)
+	return &qo
+}
+
 func TestFormatCSV(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -83,7 +89,7 @@ func TestFormatCSV(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := formatCSV(tt.result)
+			output := formatCSV(toQueryOutput(tt.result))
 
 			for _, expected := range tt.contains {
 				if !strings.Contains(output, expected) {
@@ -173,7 +179,7 @@ func TestFormatMarkdown(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := formatMarkdown(tt.result)
+			output := formatMarkdown(toQueryOutput(tt.result))
 
 			for _, expected := range tt.contains {
 				if !strings.Contains(output, expected) {


### PR DESCRIPTION
## Summary

Implements all three items from #57, plus a consistency fix for `trino_explain`:

- **Format validation**: Invalid `format` values (e.g. `tsv`, `JSON`, `table`) now return a clear error naming the accepted values (`json`, `csv`, `markdown`) instead of silently falling through to JSON. Applied to both `trino_query` and `trino_execute`.
- **Tool description prose**: Both tool descriptions now mention `format` and `unwrap_json` so MCP agents discover them without needing to inspect parameter-level schema descriptions.
- **Opt-in JSON unwrap**: New `unwrap_json` boolean parameter (default `false`) on both tools. When enabled and the result is exactly one row with one string-type column (VARCHAR, CHAR, or JSON) containing a valid JSON object or array, the value is parsed inline and `columns[0].type` is set to `"JSON"`. The envelope shape is identical to the non-unwrap case — same `columns`, `rows`, `row_count`, `stats` structure. Consumers can branch on `columns[0].type == "JSON"` to know the value was unwrapped.
- **Explain type validation**: `trino_explain`'s `type` parameter now validates against accepted values (`logical`, `distributed`, `io`, `validate`) with the same pattern as `format`. **This is a breaking change**: previously, invalid values like `LOGICAL` (uppercase) silently fell through to the default; now they return an error.

## Design decisions

**Inline mutation, not a sidecar field.** The unwrapped JSON replaces the string value directly in `rows[0]` and the column type changes to `"JSON"`. There is no `unwrapped_result` field. This keeps the envelope schema identical regardless of whether unwrap fires — the only difference is the column type and the value type in the row. A consumer that today does `response.rows[0].result` and then `JSON.parse()` now does `response.rows[0].result` and skips the parse.

**Column type as the discoverability signal.** When unwrap fires, `columns[0].type` changes from `"VARCHAR"` (or `"CHAR"`, etc.) to `"JSON"`. This is an unambiguous, machine-readable signal in the existing schema. No runtime type sniffing, no flag-tracking.

**Graceful fall-through.** If `unwrap_json=true` but the result has multiple columns, multiple rows, a non-string type, the value isn't valid JSON, or the value is a JSON scalar (string, number, boolean, null), the response is byte-identical to `unwrap_json=false`.

**Shallow-copy before mutation.** `unwrapJSONColumn` copies the row map before modifying it so the original `client.QueryResult.Rows` slice is not mutated.

**Format validation is server-side only, no schema enum.** The `google/jsonschema-go` library (used by the MCP Go SDK) does not support enum constraints via struct tags. Server-side validation gives the same user-facing behavior without invasive plumbing.

## Breaking changes

- **`trino_explain` `type` parameter**: Previously, invalid values (e.g. `LOGICAL`, `unknown`) silently defaulted to `logical`. Now they return an error like `invalid explain type "LOGICAL": must be one of logical, distributed, io, validate`. Any existing caller passing uppercase or unknown type values will need to update.
- **JSON format output shape**: The JSON output now serializes `QueryOutput` (which includes a top-level `row_count` field) instead of `client.QueryResult`. This is an additive change — no fields were removed — but consumers that strictly validate the response schema will see the new field.

## Changes

| File | What |
|------|------|
| `pkg/tools/format.go` | New file: `validateFormat`, `validateExplainType`, `formatOutput`, `formatCSV`, `formatMarkdown`, `stringifyValue`, `escapeCSV`, `isStringColumnType`, `unwrapJSONColumn` |
| `pkg/tools/format_test.go` | Unit tests for all helpers: validation (10 format + 8 explain type cases), format output (4 formats + error case), `isStringColumnType` (15 types), `unwrapJSONColumn` (13 cases including scalars, CHAR, JSON type), `stringifyValue` (5 cases), end-to-end JSON and CSV format after unwrap |
| `pkg/tools/query.go` | `UnwrapJSON` field on `QueryInput`, early format validation, calls `unwrapJSONColumn` + `formatOutput` on `*QueryOutput`. Removed `formatCSV`/`formatMarkdown` (moved to format.go) |
| `pkg/tools/execute.go` | Same changes as query.go for `ExecuteInput` |
| `pkg/tools/explain.go` | Added `validateExplainType` call |
| `pkg/tools/outputs.go` | No schema changes — `QueryOutput` struct unchanged from baseline |
| `pkg/tools/descriptions.go` | Format and unwrap_json mentioned in both `ToolQuery` and `ToolExecute` descriptions |
| `pkg/tools/explain_test.go` | Removed dead test cases for inputs now rejected by validation |
| `pkg/tools/handlers_test.go` | 12 handler-level tests: invalid format (query + execute), unwrap match with JSON/CSV format, unwrap no-match, scalar no-match, execute unwrap, invalid explain type |
| `pkg/tools/query_test.go` | Updated `formatCSV`/`formatMarkdown` tests to use `*QueryOutput` |

## Test plan

- [x] `make verify` passes (lint, race tests, all packages)
- [x] `gocyclo -over 19` — no production code above threshold
- [x] Coverage: 95%+ in `pkg/tools/`
- [ ] Manual verification with a live Trino instance and a `raw_query()` table function

Closes #57